### PR TITLE
fix: field number, seperator

### DIFF
--- a/cmd/tableauc/main.go
+++ b/cmd/tableauc/main.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const version = "0.5.6"
+const version = "0.5.7"
 const (
 	ModeDefault = "default" // generate both proto and conf files
 	ModeProto   = "proto"   // generate proto files only

--- a/internal/confgen/parser.go
+++ b/internal/confgen/parser.go
@@ -1111,11 +1111,11 @@ func (sp *sheetParser) parseUnionField(field *Field, msg protoreflect.Message, r
 		return false, nil
 	}
 	valueFD := unionDesc.GetValueByNumber(fieldNumber)
-	if valueFD == nil{
+	if valueFD == nil {
 		typeValue := unionDesc.Type.Enum().Values().ByNumber(protoreflect.EnumNumber(fieldNumber)).Name()
 		err := xerrors.E2010(typeValue, fieldNumber)
 		kvs := append(rc.CellDebugKV(typeColName), xerrors.KeyPBFieldType, "enum")
-		return false, xerrors.WithMessageKV(err, kvs...) 
+		return false, xerrors.WithMessageKV(err, kvs...)
 	}
 	fieldValue := structValue.Message().NewField(valueFD)
 	if valueFD.Kind() == protoreflect.MessageKind {
@@ -1124,7 +1124,7 @@ func (sp *sheetParser) parseUnionField(field *Field, msg protoreflect.Message, r
 		msg := fieldValue.Message()
 		for i := 0; i < md.Fields().Len(); i++ {
 			fd := md.Fields().Get(i)
-			colName := prefix + field.opts.Name + unionDesc.ValueFieldName() + strconv.Itoa(i+1)
+			colName := prefix + field.opts.Name + unionDesc.ValueFieldName() + strconv.Itoa(int(fd.Number()))
 			err := func() error {
 				subField := parseFieldDescriptor(fd, sp.opts.Sep, sp.opts.Subsep)
 				defer subField.release()

--- a/internal/confgen/util.go
+++ b/internal/confgen/util.go
@@ -39,8 +39,8 @@ func parseFieldDescriptor(fd protoreflect.FieldDescriptor, sheetSep, sheetSubsep
 	span := tableaupb.Span_SPAN_DEFAULT
 	key := ""
 	layout := tableaupb.Layout_LAYOUT_DEFAULT
-	sep := ","
-	subsep := ":"
+	sep := ""
+	subsep := ""
 	optional := false
 	var prop *tableaupb.FieldProp
 

--- a/internal/confgen/version.go
+++ b/internal/confgen/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 const (
 	App     = "confgen"
-	Version = "0.4.2"
+	Version = "0.4.3"
 )
 
 func AppVersion() string {


### PR DESCRIPTION
* **Problem1**: Field number of a pb message may not be continuous, so when iterating fields, the exact field number should be used to concatenate the `colName`, rather than the loop index `i+1`.
* **Problem2**: When deciding to use which seperator, tableauc works like this: First, use **field seperator** if it has one. Second, use **worksheet seperator** if it has one. Finally, use the **default seperator** `","` if neither of above is assigned. So `sep` and `subsep` should be declared as an empty string first, to ensure the **worksheet seperator** works correctly.