### PR TITLE
load(BREAKING)!: move Filter option to loader

### DIFF
--- a/load/load_test.go
+++ b/load/load_test.go
@@ -28,18 +28,6 @@ func TestLoad(t *testing.T) {
 		errcode string
 	}{
 		{
-			name: "load-origin",
-			args: args{
-				msg: &unittestpb.ItemConf{},
-				dir: "../testdata/",
-				fmt: format.CSV,
-				options: []Option{
-					Filter(nil), // just for test coverage
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "load-origin-path-failed",
 			args: args{
 				msg: &unittestpb.ItemConf{},

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -28,6 +28,16 @@ func TestLoad(t *testing.T) {
 		errcode string
 	}{
 		{
+			name: "load-origin",
+			args: args{
+				msg:     &unittestpb.ItemConf{},
+				dir:     "../testdata/",
+				fmt:     format.CSV,
+				options: []Option{},
+			},
+			wantErr: false,
+		},
+		{
 			name: "load-origin-path-failed",
 			args: args{
 				msg: &unittestpb.ItemConf{},

--- a/load/options.go
+++ b/load/options.go
@@ -2,7 +2,6 @@ package load
 
 import (
 	"os"
-	"time"
 )
 
 type Options struct {
@@ -63,11 +62,6 @@ const (
 
 // ReadFunc reads the config file and returns its content.
 type ReadFunc func(name string) ([]byte, error)
-
-type Validator struct {
-	Interval     time.Duration
-	ErrorHandler func(error)
-}
 
 // Option is the functional option type.
 type Option func(*Options)

--- a/load/options.go
+++ b/load/options.go
@@ -1,6 +1,9 @@
 package load
 
-import "os"
+import (
+	"os"
+	"time"
+)
 
 type Options struct {
 	// Filter can only filter in certain specific messagers based on the
@@ -55,6 +58,9 @@ type Options struct {
 	//
 	// Default: ModeDefault.
 	Mode LoadMode
+	// Validator enables the immutability validation of the loaded config, and
+	// specifies its interval and error handler.
+	Validator *Validator
 }
 
 type LoadMode int
@@ -72,6 +78,11 @@ type FilterFunc func(name string) bool
 
 // ReadFunc reads the config file and returns its content.
 type ReadFunc func(name string) ([]byte, error)
+
+type Validator struct {
+	Interval     time.Duration
+	ErrorHandler func(error)
+}
 
 // Option is the functional option type.
 type Option func(*Options)
@@ -169,5 +180,18 @@ func PatchDirs(dirs ...string) Option {
 func Mode(mode LoadMode) Option {
 	return func(opts *Options) {
 		opts.Mode = mode
+	}
+}
+
+// WithValidator enables the immutability validation of the loaded config, and
+// specifies its interval and error handler.
+func WithValidator(interval time.Duration, handler func(error)) Option {
+	return func(opts *Options) {
+		if interval != 0 && handler != nil {
+			opts.Validator = &Validator{
+				Interval:     interval,
+				ErrorHandler: handler,
+			}
+		}
 	}
 }

--- a/load/options.go
+++ b/load/options.go
@@ -1,8 +1,6 @@
 package load
 
-import (
-	"os"
-)
+import "os"
 
 type Options struct {
 	// ReadFunc reads the config file and returns its content.

--- a/load/options.go
+++ b/load/options.go
@@ -6,13 +6,6 @@ import (
 )
 
 type Options struct {
-	// Filter can only filter in certain specific messagers based on the
-	// condition that you provide.
-	//
-	// NOTE: only used in https://github.com/tableauio/loader.
-	//
-	// Default: nil.
-	Filter FilterFunc
 	// ReadFunc reads the config file and returns its content.
 	//
 	// Default: os.ReadFile.
@@ -58,9 +51,6 @@ type Options struct {
 	//
 	// Default: ModeDefault.
 	Mode LoadMode
-	// Validator enables the immutability validation of the loaded config, and
-	// specifies its interval and error handler.
-	Validator *Validator
 }
 
 type LoadMode int
@@ -70,11 +60,6 @@ const (
 	ModeOnlyMain                  // Only load the main file
 	ModeOnlyPatch                 // Only load the patch files
 )
-
-// FilterFunc filter in messagers if returned value is true.
-//
-// NOTE: name is the protobuf message name, e.g.: "message ItemConf{...}".
-type FilterFunc func(name string) bool
 
 // ReadFunc reads the config file and returns its content.
 type ReadFunc func(name string) ([]byte, error)
@@ -103,16 +88,6 @@ func ParseOptions(setters ...Option) *Options {
 		setter(opts)
 	}
 	return opts
-}
-
-// Filter can only filter in certain specific messagers based on the
-// condition that you provide.
-//
-// NOTE: only used in https://github.com/tableauio/loader.
-func Filter(filter FilterFunc) Option {
-	return func(opts *Options) {
-		opts.Filter = filter
-	}
 }
 
 // ReadFunc reads the config file and returns its content.
@@ -180,18 +155,5 @@ func PatchDirs(dirs ...string) Option {
 func Mode(mode LoadMode) Option {
 	return func(opts *Options) {
 		opts.Mode = mode
-	}
-}
-
-// WithValidator enables the immutability validation of the loaded config, and
-// specifies its interval and error handler.
-func WithValidator(interval time.Duration, handler func(error)) Option {
-	return func(opts *Options) {
-		if interval != 0 && handler != nil {
-			opts.Validator = &Validator{
-				Interval:     interval,
-				ErrorHandler: handler,
-			}
-		}
 	}
 }


### PR DESCRIPTION
## ❗BREAKING CHANGE

In file *load/options.go*, we deleted the load option `Filter` for design consistency. Now you can find this option in the generated code in loader, and use this option in `tableau.NewHub`.

## Compatibility resolution
- Assign the filter func when initializing the hub

Old：
```go
hub := tableau.NewHub()
err := hub.Load(configDir, format.JSON,
    load.IgnoreUnknownFields(),
    load.Filter(yourCustomFilter),
)
```

New:
```go
hub := tableau.NewHub(tableau.Filter(yourCustomFilter))
err := hub.Load(configDir, format.JSON,
    load.IgnoreUnknownFields(),
)
```