### PR TITLE
feat: remove useless withCode

### DIFF
--- a/internal/protogen/exporter.go
+++ b/internal/protogen/exporter.go
@@ -289,7 +289,7 @@ func (x *sheetExporter) exportUnion() error {
 func (x *sheetExporter) exportMessager() error {
 	// log.Debugf("workbook: %s", x.ws.String())
 	if x.be.messagerPatternRegexp != nil && !x.be.messagerPatternRegexp.MatchString(x.ws.Name) {
-		return xerrors.Errorf("messager %s does not match pattern %s", x.ws.Name, x.be.messagerPatternRegexp.String())
+		return xerrors.Errorf("messager %s does not match pattern %q", x.ws.Name, x.be.messagerPatternRegexp.String())
 	}
 	x.g.P("message ", x.ws.Name, " {")
 	x.g.P("  option (tableau.worksheet) = {", marshalToText(x.ws.Options), "};")

--- a/xerrors/desc.go
+++ b/xerrors/desc.go
@@ -100,7 +100,9 @@ func NewDesc(err error) *Desc {
 		kv := strings.SplitN(s, ":", 2)
 		if len(kv) == 2 {
 			key, val := strings.Trim(kv[0], " :"), strings.Trim(kv[1], " :")
-			desc.setField(key, val)
+			if key != "" && val != "" {
+				desc.setField(key, val)
+			}
 		}
 	}
 	return desc

--- a/xerrors/errors.go
+++ b/xerrors/errors.go
@@ -1,8 +1,7 @@
 //   Error handling model:
 // 			1. cause error(nil means no cause) is wrapped by base error with caller stack
 //          2. all errors contain only one caller stack
-//          3. withMessage is an error whitch has a message, which could be infinitely
-// 		       nested with each other
+//          3. withMessage is an error with a message, which could be infinitely nested with each other
 //
 //                                 +---------+
 //                                 |  cause  |

--- a/xerrors/errors.go
+++ b/xerrors/errors.go
@@ -159,8 +159,7 @@ func combineKV(keysAndValues ...any) string {
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.
 // Errorf also records the code and stack trace at the point it was called.
-// func Errorf(code int, format string, args ...interface{}) error {
-func Errorf(format string, args ...interface{}) error {
+func Errorf(format string, args ...any) error {
 	return &withMessage{
 		cause:   &base{stack: callers()},
 		message: combineKV(KeyReason, fmt.Sprintf(format, args...)),
@@ -180,7 +179,7 @@ func ErrorKV(msg string, keysAndValues ...any) error {
 // Wrapf returns an error annotating err with a stack trace
 // at the point Wrapf is called, and the format specifier.
 // If err is nil, Wrapf returns nil.
-func Wrapf(err error, format string, args ...interface{}) error {
+func Wrapf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/xerrors/errors.go
+++ b/xerrors/errors.go
@@ -1,9 +1,8 @@
 //   Error handling model:
 // 			1. cause error(nil means no cause) is wrapped by base error with caller stack
 //          2. all errors contain only one caller stack
-//          3. withCode is an error which has a code
-//          4. withMessage is an error whitch has a message
-//          5. withCode and withMessage could be infinitely nested and nested with each other
+//          3. withMessage is an error whitch has a message, which could be infinitely
+// 		       nested with each other
 //
 //                                 +---------+
 //                                 |  cause  |
@@ -18,17 +17,17 @@
 //                                      |
 //                 +----------------------------------------+
 //                 |                                        |
-//            +----+-----+                           +------+------+
-//            | withCode |                           | withMessage |
-//            +----+-----+                           +------+------+
+//          +------+------+                          +------+------+
+//          | withMessage |                          | withMessage |
+//          +------+------+                          +------+------+
 //                 |                                        |
-//          +------+------+                           +-----+----+
-//          | withMessage |                           | withCode |
-//          +------+------+                           +-----+----+
+//          +------+------+                          +------+------+
+//          | withMessage |                          | withMessage |
+//          +------+------+                          +------+------+
 //                 |                                        |
-//            +----+-----+                           +------+------+
-//            | withCode |                           | withMessage |
-//            +----+-----+                           +------+------+
+//          +------+------+                          +------+------+
+//          | withMessage |                          | withMessage |
+//          +------+------+                          +------+------+
 //                 |                                        |
 
 package xerrors
@@ -69,52 +68,6 @@ func (b *base) Format(s fmt.State, verb rune) {
 				b.stack.Format(s, verb)
 			}
 			return
-		}
-		fallthrough
-	case 's':
-		_, _ = io.WriteString(s, content)
-	case 'q':
-		_, _ = fmt.Fprintf(s, "%q", content)
-	}
-}
-
-// withCode is an error that has a cause error and code.
-type withCode struct {
-	cause error
-	code  int
-}
-
-func (w *withCode) Error() string {
-	// content := fmt.Sprintf("%d(%s)", w.code, w.code.String())
-	content := fmt.Sprintf("%d", w.code)
-	if w.cause != nil {
-		// don't use %+v to avoid printing duplicated stack
-		content += ": " + w.cause.Error()
-	}
-	return content
-}
-
-func (w *withCode) Code() int {
-	return w.code
-}
-
-// Unwrap provides compatibility for Go 1.13 error chains.
-func (w *withCode) Unwrap() error { return w.cause }
-
-func (w *withCode) Cause() error { return w.cause }
-
-func (w *withCode) Format(s fmt.State, verb rune) {
-	// content := fmt.Sprintf("%d(%s)", w.code, w.code.String())
-	content := fmt.Sprintf("%d", w.code)
-	switch verb {
-	case 'v':
-		if s.Flag('+') {
-			if w.cause != nil {
-				cause := fmt.Sprintf("%+v", w.cause)
-				if cause != "" {
-					content += ": " + cause
-				}
-			}
 		}
 		fallthrough
 	case 's':
@@ -172,23 +125,17 @@ func withStack(err error) error {
 	}
 	cerr := Cause(err)
 	if cerr == nil {
-		return &withCode{
-			code: -1,
-			cause: &base{
-				cause: err,
-				stack: callers(),
-			},
+		return &base{
+			cause: err,
+			stack: callers(),
 		}
 	}
 
 	berr, ok := cerr.(*base)
 	if !ok || berr == nil {
-		return &withCode{
-			code: -1,
-			cause: &base{
-				cause: err,
-				stack: callers(),
-			},
+		return &base{
+			cause: err,
+			stack: callers(),
 		}
 	}
 	if berr.stack == nil {
@@ -209,28 +156,14 @@ func combineKV(keysAndValues ...any) string {
 	return msg
 }
 
-// New returns an error with the supplied code and message.
-// New also records the stack trace at the point it was called
-func New(code int) error {
-	return &withCode{cause: &base{stack: callers()}, code: code}
-}
-
-// NewStackless returns an error without caller stack.
-func NewStackless(code int) error {
-	return &withCode{cause: new(base), code: code}
-}
-
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.
 // Errorf also records the code and stack trace at the point it was called.
 // func Errorf(code int, format string, args ...interface{}) error {
 func Errorf(format string, args ...interface{}) error {
-	return &withCode{
-		code: -1,
-		cause: &withMessage{
-			cause:   &base{stack: callers()},
-			message: combineKV(KeyReason, fmt.Sprintf(format, args...)),
-		},
+	return &withMessage{
+		cause:   &base{stack: callers()},
+		message: combineKV(KeyReason, fmt.Sprintf(format, args...)),
 	}
 }
 
@@ -238,12 +171,9 @@ func Errorf(format string, args ...interface{}) error {
 // as `[|key: value]...` string.
 // ErrorKV also records the stack trace at the point it was called.
 func ErrorKV(msg string, keysAndValues ...any) error {
-	return &withCode{
-		code: -1,
-		cause: &withMessage{
-			cause:   &base{stack: callers()},
-			message: combineKV(keysAndValues...) + combineKV(KeyReason, msg),
-		},
+	return &withMessage{
+		cause:   &base{stack: callers()},
+		message: combineKV(keysAndValues...) + combineKV(KeyReason, msg),
 	}
 }
 
@@ -281,25 +211,6 @@ func Wrap(err error) error {
 	return Wrapf(err, "")
 }
 
-// WithCodef wraps error with a code and formated message.
-func WithCodef(err error, code int, format string, args ...interface{}) error {
-	if err == nil {
-		return nil
-	}
-	err = withStack(err)
-	message := fmt.Sprintf(format, args...)
-	if message != "" {
-		err = &withMessage{cause: err, message: message}
-	}
-	err = &withCode{cause: err, code: code}
-	return err
-}
-
-// WithCode wraps error with a code.
-func WithCode(err error, code int) error {
-	return WithCodef(err, code, "")
-}
-
 // Cause returns the underlying cause of the error, if possible.
 // An error value has a cause if it implements the following
 // interface:
@@ -324,28 +235,4 @@ func Cause(err error) error {
 		err = cause.Cause()
 	}
 	return err
-}
-
-// Code returns the code of top-level error.
-func Code(err error) int {
-	if err == nil {
-		return 0
-	}
-	for err != nil {
-		cause, ok := err.(xcauser)
-		if !ok {
-			break
-		}
-		if w, ok := err.(*withCode); ok {
-			return w.Code()
-		}
-		err = cause.Cause()
-	}
-
-	return -1
-}
-
-// Is reports whether any error in err's tree matches code.
-func Is(err error, code int) bool {
-	return Code(err) == code
 }


### PR DESCRIPTION
When a messager name fails to match the required pattern, error messages of protogen contains a suspicious `: -1` after SheetName. This is because `xerrors.Errorf` creates an error with error code `-1` whose error message is like `-1: |Reason: messager <name> does not match pattern <pattern>`, and when it's wrapped with kvs, it becomes `SheetName: <sheetname>: -1: |Reason: messager <name> does not match pattern <pattern>`. `xerrors.Desc` splits the error message and parses its sheetname as `<sheetname>: -1`.

<img width="406" height="140" alt="企业微信截图_17531686753245" src="https://github.com/user-attachments/assets/89e86f9e-5722-4327-849a-9d3c4cfb125f" />
