### PR TITLE
fix(log): only output log to console after `log.Init` is called

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -22,10 +22,6 @@ var atomicLevel zap.AtomicLevel
 func init() {
 	defaultLogger = &Logger{
 		level: core.DebugLevel,
-		// driver: &defaultdriver.DefaultDriver{
-		// 	CallerSkip: 1,
-		// },
-		driver: zapdriver.New(zap.NewDevelopmentConfig(), zap.AddCallerSkip(4)),
 	}
 	gOpts = &Options{}
 	atomicLevel = zap.NewAtomicLevelAt(zap.DebugLevel)

--- a/log/logger.go
+++ b/log/logger.go
@@ -165,6 +165,10 @@ func (l *Logger) log(lvl core.Level, format string, fmtArgs []any, kvs []any) {
 	// 	return
 	// }
 
+	if l.driver == nil {
+		return
+	}
+
 	r := &core.Record{
 		Level:  lvl,
 		Format: &format,


### PR DESCRIPTION
- close #344
If the user wants logging, should call `log.Init` manually. 