### PR TITLE
feat: retract github.com/tableauio/tableau/cmd/tableauc v0.7.x

### DIFF
--- a/cmd/tableauc/module-retract/go.mod
+++ b/cmd/tableauc/module-retract/go.mod
@@ -2,5 +2,6 @@ module github.com/tableauio/tableau/cmd/tableauc
 
 go 1.20
 
-// This entire range of versions was published accidentally
+// This entire range of versions was published accidentally.
+// See https://github.com/tableauio/tableau/pull/353 for details.
 retract [v0.0.0-00000000000000-000000000000, v0.7.2-do-not-use]


### PR DESCRIPTION
## Problem
We tried to add a subdirectory module "github.com/tableauio/tableau/cmd/tableauc" in dir **cmd/tableauc** in PR (https://github.com/tableauio/tableau/pull/180), and it uses the `replace` directive in go mod file.
However, `go install` not works as the go module official docs say (https://go.dev/blog/go116-module-changes#installing-an-executable-at-a-specific-version)

> In order to eliminate ambiguity about which versions are used, there are several restrictions on what directives may be present in the program’s go.mod file when using this install syntax. In particular, `replace` and `exclude` directives are not allowed, at least for now.

So we have to rollback the PR https://github.com/tableauio/tableau/pull/180 by a new PR https://github.com/tableauio/tableau/pull/181. But he already published module version [cmd/tableauc v0.7.1](https://pkg.go.dev/github.com/tableauio/tableau/cmd/tableauc?tab=versions) remains forever, and the go install command

```bash
go install github.com/tableauio/tableau/cmd/tableauc@latest
```

will forever use the subdirectory "cmd/tableauc" v0.7.1 but not he main module version.

## Solution
Use the **Module retraction** to rectract the bad versions. Specially, the ultimate solution is **retracting all versions up to that point** (see https://github.com/golang/go/issues/49015#issuecomment-944993211).

Retract the bad version  "cmd/tableauc" v0.7.1 and make the future versions as the correct **latest** version
recognized by go toolchain.

References:
- https://go.dev/blog/go116-module-changes#module-retraction
- https://github.com/golang/go/issues/49015
- https://github.com/golang/go/issues/49015#issuecomment-944993211
- https://pkg.go.dev/about

The thrift library revolves it by
- https://github.com/apache/thrift/releases/tag/lib%2Fgo%2Fthrift%2Fv0.0.1-do-not-use
- https://github.com/apache/thrift/commit/a62b40c3dfbbc109ca9f6cbe4edc47abb7394f88

We should resolve it by
1. Checkout new branch: `retract-v7.0.x`
2. Add or modify the *cmd/tableauc/go.mod* as
```
module github.com/tableauio/tableau/cmd/tableauc

go 1.21

// This entire range of versions was published accidentally.
// See https://github.com/tableauio/tableau/pull/353 for details.
retract [v0.0.0, v0.7.4]
```
3. Tag and push
  ```bash
  git tag cmd/tableauc/v0.7.4
  git push origin cmd/tableauc/v0.7.4
  ```
4. Wait for some time for pkg.go.dev to refresh cache (or manually refresh it)
5. Keep sure the subdirectory module *cmd/tableauc/go.mod* has been removed in master branch
6. Tag new version (over v0.7.4) on master branch