### PR TITLE
fix(protogen): skip TYPE_INVALID=0 in union when enum value 0 is user-specified

### DIFF
--- a/internal/protogen/exporter.go
+++ b/internal/protogen/exporter.go
@@ -3,6 +3,7 @@ package protogen
 import (
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
@@ -275,6 +276,10 @@ func (x *sheetExporter) exportUnion() error {
 	x.p.P()
 
 	for _, field := range x.ws.Fields {
+		// Skip enum value 0
+		if field.Number == 0 {
+			continue
+		}
 		ename := "TYPE_" + strcase.FromContext(x.be.gen.ctx).ToScreamingSnake(field.Name)
 		typ := field.Name
 		if field.FullType != "" {
@@ -291,7 +296,10 @@ func (x *sheetExporter) exportUnion() error {
 
 	// generate enum type
 	x.p.P("  enum Type {")
-	x.p.P("    TYPE_INVALID = 0;")
+	// Only emit TYPE_INVALID = 0 if no field has already claimed number 0.
+	if !slices.ContainsFunc(x.ws.Fields, func(f *internalpb.Field) bool { return f.Number == 0 }) {
+		x.p.P("    TYPE_INVALID = 0;")
+	}
 	for _, field := range x.ws.Fields {
 		ename := "TYPE_" + strcase.FromContext(x.be.gen.ctx).ToScreamingSnake(field.Name)
 		note := ""

--- a/test/functest/proto/default/excel__metasheet__sheet_mode.proto
+++ b/test/functest/proto/default/excel__metasheet__sheet_mode.proto
@@ -241,7 +241,7 @@ message TaskTarget {
   }
 
   enum Type {
-    TYPE_INVALID = 0;
+    TYPE_UNKNOWN = 0 [(tableau.evalue).name = "AliasUnknown"]; // AliasUnknown
     TYPE_PVP = 1 [(tableau.evalue).name = "AliasPVP"]; // AliasPVP
     TYPE_PVE = 2 [(tableau.evalue).name = "AliasPVE"]; // AliasPVE
     TYPE_STORY = 3 [(tableau.evalue).name = "AliasStory"]; // AliasStory
@@ -300,7 +300,7 @@ message WishTarget {
   }
 
   enum Type {
-    TYPE_INVALID = 0;
+    TYPE_UNKNOWN = 0 [(tableau.evalue).name = ""];
     TYPE_HIGHER = 1 [(tableau.evalue).name = "WishHigher"]; // WishHigher
     TYPE_RICHER = 2 [(tableau.evalue).name = "WishRicher"]; // WishRicher
   }

--- a/test/functest/testdata/default/excel/metasheet/SheetMode#UnionTaskTarget.csv
+++ b/test/functest/testdata/default/excel/metasheet/SheetMode#UnionTaskTarget.csv
@@ -1,35 +1,36 @@
-Name,Alias,Field1,Field2,Field3
-PVP,AliasPVP,"ID
+Number,Name,Alias,Field1,Field2,Field3
+0,Unknown,AliasUnknown,,,
+1,PVP,AliasPVP,"ID
 uint32
 Note","Damage
 int64
 Note","Type
 []enum<.FruitType>
 Note"
-PVE,AliasPVE,"Mission
+2,PVE,AliasPVE,"Mission
 {uint32 ID, enum<.ItemType> Type}Mission
 Note","Hero
 []uint32
 Note","Dungeon
 map<int32, int64>
 Note"
-Story,AliasStory,"Cost
+3,Story,AliasStory,"Cost
 {.Item}
 Note","Fruit
 map<int32, enum<.FruitType>>
 Note","Flavor
 map<enum<.FruitFlavor>, enum<.FruitType>>
 Note"
-Hobby,AliasHobby,"Flavor
+4,Hobby,AliasHobby,"Flavor
 map<enum<.FruitFlavor>, enum<.FruitType>>
 Note","StartTime
 datetime
 Note","Duration
 duration
 Note"
-Skill,AliasSkill,"ID
+5,Skill,AliasSkill,"ID
 uint32
 Note","Damage
 int64
 Note",
-Empty,AliasEmpty,,,
+6,Empty,AliasEmpty,,,

--- a/test/functest/testdata/default/excel/metasheet/SheetMode#UnionType.csv
+++ b/test/functest/testdata/default/excel/metasheet/SheetMode#UnionType.csv
@@ -1,39 +1,40 @@
-WishTarget,WishTarget note,,,
-Name,Alias,Field1,Field2,Field3
-Higher,WishHigher,"Height
+WishTarget,WishTarget note,,,,
+Number,Name,Alias,Field1,Field2,Field3
+0,Unknown,,,,
+1,Higher,WishHigher,"Height
 int32",,
-Richer,WishRicher,"ID
+2,Richer,WishRicher,"ID
 uint32","Bank
 map<int32, string>",
-,,,,
-HeroTarget,HeroTarget note,,,
-Name,Alias,Field1,Field2,Field3
+,,,,,
+HeroTarget,HeroTarget note,,,,
+Name,Alias,Field1,Field2,Field3,
 StarUp,HeroStarUp,"ID
 uint32","Star
-int32",
+int32",,
 LevelUp,HeroLevelUp,"ID
 []uint32","Level
 int32","Super
-bool"
-,,,,
-,,,,
-,,,,
-BattleTarget,BattleTarget note,,,
-Name,Alias,Field1,Field2,Field3
+bool",
+,,,,,
+,,,,,
+,,,,,
+BattleTarget,BattleTarget note,,,,
+Name,Alias,Field1,Field2,Field3,
 PVP,BattlePVP,"BattleID
 int32","Damage
-int64",
+int64",,
 PVE,BattlePVE,"HeroID
 []int32","Dungeon
 map<int32, int64>","Boss
-{uint32 ID, int64 Damage}Boss"
-,,,,
-ColumnDisorderedUnion,ColumnDisorderedUnion note,,,
-Field3,Name,Field2,Alias,Field1
+{uint32 ID, int64 Damage}Boss",
+,,,,,
+ColumnDisorderedUnion,ColumnDisorderedUnion note,,,,
+Field3,Name,Field2,Alias,Field1,
 ,Goblin,"Damage
 int64",MonsterGoblin,"HP
-int32"
+int32",
 "Gold
 int32",Kobold,"Weapon
 string",MonsterKobold,"HP
-int32"
+int32",


### PR DESCRIPTION
## Problem

When a union sheet has a field with enum value number 0 (user-specified), the protogen was still unconditionally emitting `TYPE_INVALID = 0` in the `enum Type` block, causing a duplicate enum value conflict.

Additionally, the `oneof value` block was printing a `// No field bound to enum value` comment for the number-0 field, which is misleading since it corresponds to the user-defined zero value.

## Changes

- **`internal/protogen/exporter.go`**:
  - Skip generating `TYPE_INVALID = 0` in the `enum Type` block if any field already has `Number == 0` (using `slices.ContainsFunc` for a clean one-liner check).
  - Skip printing any output in the `oneof value` block for fields with `Number == 0` via an early `continue`.

## Test

Updated functional test data (`SheetMode#UnionType.csv`, `SheetMode#UnionTaskTarget.csv`) and the expected proto output (`excel__metasheet__sheet_mode.proto`) to cover the case where enum value 0 is user-specified.