### PR TITLE
refactor(wellknown): streamline Fraction comparison and drop LocalTime helper

### DIFF
--- a/proto/tableaupb/wellknown_util.go
+++ b/proto/tableaupb/wellknown_util.go
@@ -1,10 +1,6 @@
 package tableaupb
 
-import (
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
-)
+import "math/big"
 
 // NewFraction creates a new fraction.
 func NewFraction(num, den int32) *Fraction {
@@ -36,34 +32,33 @@ func NewIntegerComparator(sign Comparator_Sign, num int32) *Comparator {
 
 // Compare returns true if the given fraction matches the given comparator.
 func Compare(left *Fraction, cmp *Comparator) bool {
-	right := cmp.GetValue()
-	// cross-multiply to compare
-	lval := int64(left.GetNum()) * int64(right.GetDen())
-	rval := int64(right.GetNum()) * int64(left.GetDen())
-	switch cmp.GetSign() {
-	case Comparator_SIGN_EQUAL:
-		return lval == rval
-	case Comparator_SIGN_NOT_EQUAL:
-		return lval != rval
-	case Comparator_SIGN_LESS:
-		return lval < rval
-	case Comparator_SIGN_LESS_OR_EQUAL:
-		return lval <= rval
-	case Comparator_SIGN_GREATER:
-		return lval > rval
-	case Comparator_SIGN_GREATER_OR_EQUAL:
-		return lval >= rval
-	default:
-		panic("invalid compare operator")
-	}
+	return left.Cmp(cmp)
 }
 
-// LocalTime converts a timestamp to a local time.
-//
-// NOTE: The [Timestamp.AsTime] method returns a UTC time, so we provide
-// [LocalTime] to convert it to a local time for easy use.
-//
-// [Timestamp.AsTime]: https://pkg.go.dev/google.golang.org/protobuf/types/known/timestamppb#Timestamp.AsTime
-func LocalTime(ts *timestamppb.Timestamp) time.Time {
-	return ts.AsTime().Local()
+func (f *Fraction) AsRat() *big.Rat {
+	return big.NewRat(int64(f.GetNum()), int64(f.GetDen()))
+}
+
+var cmpResult = map[int]map[Comparator_Sign]bool{
+	-1: {
+		Comparator_SIGN_NOT_EQUAL:     true,
+		Comparator_SIGN_LESS:          true,
+		Comparator_SIGN_LESS_OR_EQUAL: true,
+	},
+	0: {
+		Comparator_SIGN_EQUAL:            true,
+		Comparator_SIGN_LESS_OR_EQUAL:    true,
+		Comparator_SIGN_GREATER_OR_EQUAL: true,
+	},
+	1: {
+		Comparator_SIGN_NOT_EQUAL:        true,
+		Comparator_SIGN_GREATER:          true,
+		Comparator_SIGN_GREATER_OR_EQUAL: true,
+	},
+}
+
+func (f *Fraction) Cmp(cmp *Comparator) bool {
+	self := f.AsRat()
+	other := cmp.GetValue().AsRat()
+	return cmpResult[self.Cmp(other)][cmp.GetSign()]
 }

--- a/proto/tableaupb/wellknown_util.go
+++ b/proto/tableaupb/wellknown_util.go
@@ -1,7 +1,5 @@
 package tableaupb
 
-import "math/big"
-
 // NewFraction creates a new fraction.
 func NewFraction(num, den int32) *Fraction {
 	return &Fraction{Num: num, Den: den}
@@ -33,10 +31,6 @@ func NewIntegerComparator(sign Comparator_Sign, num int32) *Comparator {
 // Compare returns true if the given fraction matches the given comparator.
 func Compare(left *Fraction, cmp *Comparator) bool {
 	return left.Cmp(cmp)
-}
-
-func (f *Fraction) AsRat() *big.Rat {
-	return big.NewRat(int64(f.GetNum()), int64(f.GetDen()))
 }
 
 func (f *Fraction) Cmp(cmp *Comparator) bool {

--- a/proto/tableaupb/wellknown_util.go
+++ b/proto/tableaupb/wellknown_util.go
@@ -39,26 +39,25 @@ func (f *Fraction) AsRat() *big.Rat {
 	return big.NewRat(int64(f.GetNum()), int64(f.GetDen()))
 }
 
-var cmpResult = map[int]map[Comparator_Sign]bool{
-	-1: {
-		Comparator_SIGN_NOT_EQUAL:     true,
-		Comparator_SIGN_LESS:          true,
-		Comparator_SIGN_LESS_OR_EQUAL: true,
-	},
-	0: {
-		Comparator_SIGN_EQUAL:            true,
-		Comparator_SIGN_LESS_OR_EQUAL:    true,
-		Comparator_SIGN_GREATER_OR_EQUAL: true,
-	},
-	1: {
-		Comparator_SIGN_NOT_EQUAL:        true,
-		Comparator_SIGN_GREATER:          true,
-		Comparator_SIGN_GREATER_OR_EQUAL: true,
-	},
-}
-
 func (f *Fraction) Cmp(cmp *Comparator) bool {
-	self := f.AsRat()
-	other := cmp.GetValue().AsRat()
-	return cmpResult[self.Cmp(other)][cmp.GetSign()]
+	other := cmp.GetValue()
+	// cross-multiply to compare
+	lval := int64(f.GetNum()) * int64(other.GetDen())
+	rval := int64(other.GetNum()) * int64(f.GetDen())
+	switch cmp.GetSign() {
+	case Comparator_SIGN_EQUAL:
+		return lval == rval
+	case Comparator_SIGN_NOT_EQUAL:
+		return lval != rval
+	case Comparator_SIGN_LESS:
+		return lval < rval
+	case Comparator_SIGN_LESS_OR_EQUAL:
+		return lval <= rval
+	case Comparator_SIGN_GREATER:
+		return lval > rval
+	case Comparator_SIGN_GREATER_OR_EQUAL:
+		return lval >= rval
+	default:
+		panic("invalid compare operator")
+	}
 }

--- a/proto/tableaupb/wellknown_util_test.go
+++ b/proto/tableaupb/wellknown_util_test.go
@@ -2,11 +2,7 @@ package tableaupb
 
 import (
 	"math"
-	"reflect"
 	"testing"
-	"time"
-
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestCompare(t *testing.T) {
@@ -80,42 +76,6 @@ func TestCompare(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Compare(tt.args.left, tt.args.cmp); got != tt.want {
 				t.Errorf("Compare() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func localTime(value string) time.Time {
-	loc, _ := time.LoadLocation("Local")
-	t, _ := time.ParseInLocation(time.DateTime, value, loc)
-	return t
-}
-
-func TestLocalTime(t *testing.T) {
-	type args struct {
-		ts *timestamppb.Timestamp
-	}
-	tests := []struct {
-		name string
-		args args
-		want time.Time
-	}{
-		{
-			name: "local time",
-			args: args{
-				ts: timestamppb.New(localTime("2021-08-30 00:00:00")),
-			},
-			want: localTime("2021-08-30 00:00:00"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := LocalTime(tt.args.ts)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("LocalTime() = %v, want %v", got, tt.want)
-			}
-			if got.Location() == time.UTC {
-				t.Errorf("Location = %v, want Local", got.Location().String())
 			}
 		})
 	}


### PR DESCRIPTION
### Summary
Cleans up `proto/tableaupb/wellknown_util.go` by simplifying fraction comparison, promoting it to an idiomatic receiver-style method, and removing the redundant `LocalTime` helper.

### Changes

**1. `Fraction` comparison refactor**
- Introduce `(*Fraction).Cmp(cmp *Comparator) bool` as the canonical comparison entry point; the package-level `Compare` is kept as a thin wrapper for backward compatibility.

**2. Remove `LocalTime`**
- Delete `LocalTime(ts *timestamppb.Timestamp) time.Time` and its test.
- Callers can use `ts.AsTime().Local()` directly; the one-line wrapper added no real value and pulled `time` / `timestamppb` imports into this file unnecessarily.

### Compatibility
- `Compare(left, cmp)` signature is unchanged — existing callers keep working.
- `LocalTime` is removed; replace any usage with `ts.AsTime().Local()`.
