### PR TITLE
feat(protogen): infer feature imports from ProtoFileOptions and sort options deterministically

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [master, main]
+    branches: [ master, main ]
   pull_request:
-    branches: [master, main]
+    branches: [ master, main ]
 
 jobs:
   golangci:

--- a/.github/workflows/publish-module-to-bsr.yml
+++ b/.github/workflows/publish-module-to-bsr.yml
@@ -2,8 +2,8 @@ name: Publish modules to the BSR
 
 on:
   push:
-    branches: [master, main]
-    tags: ["*"]
+    branches: [ master, main ]
+    tags: [ "*" ]
 
 jobs:
   push-module:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch:
 
 jobs:
@@ -12,8 +12,8 @@ jobs:
     if: startsWith(github.event.release.tag_name, 'cmd/tableauc/')
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
+        goos: [ linux, darwin, windows ]
+        goarch: [ amd64, arm64 ]
         exclude:
           - goos: linux
             goarch: arm64

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Testing
 # Trigger on pushes, PRs (excluding documentation changes), and nightly.
 on:
   push:
-    branches: [master, main]
+    branches: [ master, main ]
   pull_request:
   schedule:
     - cron: 0 0 * * * # daily at 00:00
@@ -16,9 +16,9 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x]
-        os: [ubuntu-latest, windows-latest]
-        targetplatform: [x86, x64]
+        go-version: [ 1.24.x ]
+        os: [ ubuntu-latest, windows-latest ]
+        targetplatform: [ x86, x64 ]
 
     runs-on: ${{ matrix.os }}
 
@@ -35,7 +35,8 @@ jobs:
         run: go vet ./...
 
       - name: Unittest
-        run: go test -v -timeout 30m -race ./... -coverprofile=coverage.txt -covermode=atomic
+        run: go test -v -timeout 30m -race ./... -coverprofile=coverage.txt
+          -covermode=atomic
 
       - name: Functest
         # On Linux (ubuntu-latest), the default shell is bash.

--- a/internal/protogen/exporter.go
+++ b/internal/protogen/exporter.go
@@ -71,6 +71,19 @@ func (x *bookExporter) export(checkProtoFileConflicts bool) error {
 	// keep the elements ordered by import path
 	set := treeset.NewWithStringComparator()
 	set.Add(tableauProtoPath) // default must be imported path
+
+	// infer imports from ProtoFileOptions
+	for optionKey := range x.ProtoFileOptions {
+		switch {
+		case strings.Contains(optionKey, "features.(pb.go)"):
+			set.Add("google/protobuf/go_features.proto")
+		case strings.Contains(optionKey, "features.(pb.cpp)"):
+			set.Add("google/protobuf/cpp_features.proto")
+		case strings.Contains(optionKey, "features.(pb.java)"):
+			set.Add("google/protobuf/java_features.proto")
+		}
+	}
+
 	p3 := printer.New()
 	for i, ws := range x.wb.Worksheets {
 		se := &sheetExporter{
@@ -96,8 +109,14 @@ func (x *bookExporter) export(checkProtoFileConflicts bool) error {
 		p2.P(`import "`, key, `";`)
 	}
 	p2.P("")
-	for k, v := range x.ProtoFileOptions {
-		p2.P(`option `, k, ` = `, v, `;`)
+	// sort keys alphabetically
+	keys := make([]string, 0, len(x.ProtoFileOptions))
+	for k := range x.ProtoFileOptions {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		p2.P(`option `, k, ` = `, x.ProtoFileOptions[k], `;`)
 	}
 	p2.P("option (tableau.workbook) = {", x.marshalToText(x.wb.Options), "};")
 	p2.P("")

--- a/internal/protogen/exporter_test.go
+++ b/internal/protogen/exporter_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
@@ -291,6 +292,9 @@ func Test_bookExporter_export(t *testing.T) {
 		protoFileOptions map[string]string
 		wantContains     []string
 		wantNotContains  []string
+		// wantOrderedLines asserts the given lines appear in the generated
+		// proto file in the specified relative order.
+		wantOrderedLines []string
 	}{
 		{
 			name: "proto3",
@@ -329,9 +333,95 @@ func Test_bookExporter_export(t *testing.T) {
 				`edition = "2024";`,
 				`option go_package = "github.com/example/protoconf";`,
 				`option features.(pb.go).strip_enum_prefix = STRIP_ENUM_PREFIX_STRIP;`,
+				// go features option implies importing go_features.proto.
+				`import "google/protobuf/go_features.proto";`,
 			},
 			wantNotContains: []string{
 				`syntax = "proto3";`,
+				// must NOT import unrelated features proto files.
+				`import "google/protobuf/cpp_features.proto";`,
+				`import "google/protobuf/java_features.proto";`,
+			},
+		},
+		{
+			name:    "edition-2024-with-pb-cpp-features-infer-cpp-features-import",
+			edition: "2024",
+			protoFileOptions: map[string]string{
+				"go_package":                    `"github.com/example/protoconf"`,
+				"features.(pb.cpp).string_type": "VIEW",
+			},
+			wantContains: []string{
+				`edition = "2024";`,
+				`option features.(pb.cpp).string_type = VIEW;`,
+				`import "google/protobuf/cpp_features.proto";`,
+			},
+			wantNotContains: []string{
+				`import "google/protobuf/go_features.proto";`,
+				`import "google/protobuf/java_features.proto";`,
+			},
+		},
+		{
+			name:    "edition-2024-with-pb-java-features-infer-java-features-import",
+			edition: "2024",
+			protoFileOptions: map[string]string{
+				"go_package":                         `"github.com/example/protoconf"`,
+				"features.(pb.java).utf8_validation": "VERIFY",
+			},
+			wantContains: []string{
+				`edition = "2024";`,
+				`option features.(pb.java).utf8_validation = VERIFY;`,
+				`import "google/protobuf/java_features.proto";`,
+			},
+			wantNotContains: []string{
+				`import "google/protobuf/go_features.proto";`,
+				`import "google/protobuf/cpp_features.proto";`,
+			},
+		},
+		{
+			name:    "edition-2024-with-all-language-features-infer-all-imports",
+			edition: "2024",
+			protoFileOptions: map[string]string{
+				"go_package":                            `"github.com/example/protoconf"`,
+				"features.(pb.go).api_level":            "API_OPAQUE",
+				"features.(pb.cpp).legacy_closed_enum":  "true",
+				"features.(pb.java).legacy_closed_enum": "true",
+			},
+			wantContains: []string{
+				`import "google/protobuf/go_features.proto";`,
+				`import "google/protobuf/cpp_features.proto";`,
+				`import "google/protobuf/java_features.proto";`,
+				`option features.(pb.cpp).legacy_closed_enum = true;`,
+				`option features.(pb.go).api_level = API_OPAQUE;`,
+				`option features.(pb.java).legacy_closed_enum = true;`,
+			},
+		},
+		{
+			name: "options-sorted-alphabetically-by-key",
+			protoFileOptions: map[string]string{
+				// intentionally define keys in a non-alphabetical order
+				// to verify the output is sorted by key.
+				"java_package":     `"com.example.protoconf"`,
+				"go_package":       `"github.com/example/protoconf"`,
+				"csharp_namespace": `"Example.Protoconf"`,
+				"cc_enable_arenas": "true",
+				"optimize_for":     "SPEED",
+			},
+			wantContains: []string{
+				`option cc_enable_arenas = true;`,
+				`option csharp_namespace = "Example.Protoconf";`,
+				`option go_package = "github.com/example/protoconf";`,
+				`option java_package = "com.example.protoconf";`,
+				`option optimize_for = SPEED;`,
+			},
+			// verify the output order strictly matches alphabetical order
+			// of the keys: cc_enable_arenas < csharp_namespace < go_package
+			// < java_package < optimize_for
+			wantOrderedLines: []string{
+				`option cc_enable_arenas = true;`,
+				`option csharp_namespace = "Example.Protoconf";`,
+				`option go_package = "github.com/example/protoconf";`,
+				`option java_package = "com.example.protoconf";`,
+				`option optimize_for = SPEED;`,
 			},
 		},
 	}
@@ -377,6 +467,19 @@ func Test_bookExporter_export(t *testing.T) {
 			}
 			for _, notWant := range tt.wantNotContains {
 				assert.NotContains(t, got, notWant, "expected proto file NOT to contain: %s", notWant)
+			}
+			// verify that the expected lines appear in the given relative order.
+			if len(tt.wantOrderedLines) >= 2 {
+				prevIdx := -1
+				var prevLine string
+				for _, line := range tt.wantOrderedLines {
+					idx := strings.Index(got, line)
+					assert.GreaterOrEqual(t, idx, 0, "expected proto file to contain: %s", line)
+					assert.Greater(t, idx, prevIdx,
+						"expected line %q to appear after %q in generated proto file", line, prevLine)
+					prevIdx = idx
+					prevLine = line
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

When generating `.proto` files via `bookExporter.export`, language-specific
feature options (e.g. `features.(pb.go).*`, `features.(pb.cpp).*`,
`features.(pb.java).*`) used to require callers to also manually declare the
matching `*_features.proto` imports, and the emitted `option` lines came out
in Go's non-deterministic map iteration order.

This MR fixes both issues.

## Changes

### `internal/protogen/exporter.go`
- **Infer feature imports from `ProtoFileOptions`**. While building the import
  set, scan each option key and add the corresponding well-known proto:
  - `features.(pb.go)`   → `google/protobuf/go_features.proto`
  - `features.(pb.cpp)`  → `google/protobuf/cpp_features.proto`
  - `features.(pb.java)` → `google/protobuf/java_features.proto`
  Because imports are kept in a `treeset` keyed by path, duplicates are
  naturally deduplicated and output stays sorted by import path.
- **Emit `option` lines in alphabetical order of the key** instead of relying
  on Go's randomized map iteration, producing stable, diff-friendly output.

### `internal/protogen/exporter_test.go`
- New table-driven `Test_bookExporter_export` covering:
  - `proto3` baseline output.
  - `edition = "2023"` with `features.utf8_validation`.
  - `edition = "2024"` with `features.strip_enum_prefix`.
  - Import inference for each of `pb.go` / `pb.cpp` / `pb.java` in isolation,
    asserting that only the matching `*_features.proto` is imported.
  - All three language features together, asserting that all three imports are
    added and options appear in the file.
  - Alphabetical ordering of option keys when they are defined in a
    non-alphabetical order in the input map.
- Tests use real options defined in protobuf's `go_features.proto` /
  `cpp_features.proto` / `java_features.proto` (`api_level`, `string_type`,
  `utf8_validation`, `legacy_closed_enum`, ...) rather than synthetic names.

### `.github/workflows/*.yml` (lint / testing / release / publish-module-to-bsr)
- **Formatting-only changes produced automatically by the VSCode "GitHub
  Actions" extension on save** (e.g. `[master, main]` → `[ master, main ]`,
  minor spacing normalizations). No workflow semantics are changed.

## Compatibility

- Public API of `bookExporter` is unchanged.
- For users that already imported `*_features.proto` manually, the import set
  deduplicates via `treeset`, so no duplicate import lines are produced.
- Option output order changes from random to alphabetical, which may affect
  byte-for-byte comparisons of previously generated files but not their
  semantics.