### PR TITLE
feat(protogen): preserve stable field numbers and auto-emit `reserved` statements on regeneration

### DIFF
--- a/internal/protogen/exporter.go
+++ b/internal/protogen/exporter.go
@@ -1,6 +1,7 @@
 package protogen
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -247,7 +248,8 @@ func (x *sheetExporter) exportStruct() error {
 	x.p.P("")
 
 	oldMD := x.findMDFromGeneratedProtos(x.ws.Name)
-	x.assignFieldNumbers(x.ws.Fields, oldMD)
+	reserved := x.assignFieldNumbers(x.ws.Fields, oldMD)
+	x.printReserved(1, reserved)
 	// generate the fields
 	depth := 1
 	for _, field := range x.ws.Fields {
@@ -358,7 +360,8 @@ func (x *sheetExporter) exportUnion() error {
 		if parentMD != nil {
 			oldMD = parentMD.Messages().ByName(protoreflect.Name(typ))
 		}
-		x.assignFieldNumbers(msgField.Fields, oldMD)
+		reserved := x.assignFieldNumbers(msgField.Fields, oldMD)
+		x.printReserved(depth, reserved)
 		for _, field := range msgField.Fields {
 			var oldFD protoreflect.FieldDescriptor
 			if oldMD != nil {
@@ -398,36 +401,165 @@ func (x *sheetExporter) findMDFromGeneratedProtos(name string) protoreflect.Mess
 // assignFieldNumbers assigns the field numbers to the fields. It uses the old
 // MD to preserve field numbers if provided, otherwise it assigns field numbers
 // in sequence starting from 1.
-func (*sheetExporter) assignFieldNumbers(fields []*internalpb.Field, oldMD protoreflect.MessageDescriptor) {
+//
+// It also returns a sorted slice of field numbers that should be marked as
+// "reserved" in the regenerated proto, in order to keep the wire format
+// compatible across multiple regenerations. The returned reserved numbers
+// include:
+//  1. Pre-existing reserved ranges declared in oldMD (carried forward).
+//  2. Field numbers that exist in oldMD but whose name no longer appears in
+//     fields (i.e., fields deleted in this regeneration).
+//  3. Gap numbers in [1, maxUsedNumber] that are missing from both oldMD's
+//     active fields and oldMD's reserved ranges. Such gaps are most likely
+//     left over by a previous tableau version that deleted a field without
+//     reserving it; auto-reserving them defends future regenerations from
+//     reusing those numbers.
+//
+// Newly-added fields are assigned numbers strictly greater than the highest
+// number currently used by either an active field or a reserved entry, so
+// that a new field never collides with a reserved number.
+func (*sheetExporter) assignFieldNumbers(fields []*internalpb.Field, oldMD protoreflect.MessageDescriptor) []int32 {
 	if oldMD == nil {
 		fieldNumber := int32(1)
 		for _, field := range fields {
 			field.Number = fieldNumber
 			fieldNumber++
 		}
-		return
+		return nil
 	}
-	fieldNameNumberMap := make(map[string]int32)
-	var maxFieldNumber int32
+
+	// Collect all numbers used by oldMD: active fields plus reserved ranges.
+	// usedNumbers tracks every number that may not be reused by a NEW field.
+	// activeOldNumbers tracks numbers that were active fields in oldMD.
+	usedNumbers := make(map[int32]bool)
+	activeOldNumbers := make(map[int32]bool)
+	oldFieldNameToNumber := make(map[string]int32)
+	var maxUsedNumber int32
+
 	for i := 0; i < oldMD.Fields().Len(); i++ {
 		fd := oldMD.Fields().Get(i)
-		for _, field := range fields {
-			if string(fd.Name()) == field.Name {
-				fieldNameNumberMap[field.Name] = int32(fd.Number())
+		num := int32(fd.Number())
+		oldFieldNameToNumber[string(fd.Name())] = num
+		activeOldNumbers[num] = true
+		usedNumbers[num] = true
+		if num > maxUsedNumber {
+			maxUsedNumber = num
+		}
+	}
+
+	// Pre-existing reserved ranges in oldMD must be preserved across
+	// regenerations.
+	preservedReserved := make(map[int32]bool)
+	reservedRanges := oldMD.ReservedRanges()
+	for i := 0; i < reservedRanges.Len(); i++ {
+		r := reservedRanges.Get(i)
+		// r is [start, end) where both are protoreflect.FieldNumber.
+		for n := int32(r[0]); n < int32(r[1]); n++ {
+			preservedReserved[n] = true
+			usedNumbers[n] = true
+			if n > maxUsedNumber {
+				maxUsedNumber = n
 			}
 		}
-		maxFieldNumber = max(maxFieldNumber, int32(fd.Number()))
 	}
+
+	newFieldNames := make(map[string]bool)
 	for _, field := range fields {
-		if number, ok := fieldNameNumberMap[field.Name]; ok {
-			// for existing field, use the old field number.
-			field.Number = number
-		} else {
-			// for new field, assign the next available field number.
-			field.Number = maxFieldNumber + 1
-			maxFieldNumber = field.Number
+		newFieldNames[field.Name] = true
+	}
+
+	// Compute the reserved set:
+	//   1. Carry over pre-existing reserved entries.
+	//   2. Reserve numbers of fields deleted in this regeneration.
+	//   3. Auto-reserve gaps in [1, maxUsedNumber] not covered above and not
+	//      occupied by surviving fields.
+	reservedSet := make(map[int32]bool)
+	for n := range preservedReserved {
+		reservedSet[n] = true
+	}
+	for name, num := range oldFieldNameToNumber {
+		if !newFieldNames[name] {
+			reservedSet[num] = true
 		}
 	}
+	for n := int32(1); n <= maxUsedNumber; n++ {
+		if activeOldNumbers[n] || preservedReserved[n] {
+			continue
+		}
+		// Gap detected: previously deleted-without-reserve. Auto-reserve it.
+		reservedSet[n] = true
+	}
+
+	// Surviving fields with a stable old number are not reserved.
+	for _, field := range fields {
+		if num, ok := oldFieldNameToNumber[field.Name]; ok {
+			delete(reservedSet, num)
+		}
+	}
+
+	// Assign numbers: existing fields keep their old number; new fields get
+	// the next number that is neither used nor reserved.
+	maxFieldNumber := maxUsedNumber
+	for _, field := range fields {
+		if num, ok := oldFieldNameToNumber[field.Name]; ok {
+			// for existing field, use the old field number.
+			field.Number = num
+		} else {
+			// for new field, assign the next available field number that is
+			// not already used (active or reserved).
+			next := maxFieldNumber + 1
+			for usedNumbers[next] || reservedSet[next] {
+				next++
+			}
+			field.Number = next
+			usedNumbers[next] = true
+			maxFieldNumber = next
+		}
+	}
+
+	if len(reservedSet) == 0 {
+		return nil
+	}
+	reserved := make([]int32, 0, len(reservedSet))
+	for n := range reservedSet {
+		reserved = append(reserved, n)
+	}
+	slices.Sort(reserved)
+	return reserved
+}
+
+// formatReservedNumbers formats a sorted slice of field numbers as a single
+// proto "reserved" statement value, collapsing consecutive numbers into
+// "start to end" ranges. For example, [2, 9] becomes "2, 9" and [2, 3, 4, 9]
+// becomes "2 to 4, 9". Returns an empty string if reserved is empty.
+func formatReservedNumbers(reserved []int32) string {
+	if len(reserved) == 0 {
+		return ""
+	}
+	var parts []string
+	i := 0
+	for i < len(reserved) {
+		j := i
+		for j+1 < len(reserved) && reserved[j+1] == reserved[j]+1 {
+			j++
+		}
+		if j == i {
+			parts = append(parts, fmt.Sprintf("%d", reserved[i]))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d to %d", reserved[i], reserved[j]))
+		}
+		i = j + 1
+	}
+	return strings.Join(parts, ", ")
+}
+
+// printReserved emits a "reserved N1, N2 to N3, ...;" statement at the given
+// indentation depth if reserved is non-empty.
+func (x *sheetExporter) printReserved(depth int, reserved []int32) {
+	if len(reserved) == 0 {
+		return
+	}
+	x.p.P(printer.Indent(depth), "reserved ", formatReservedNumbers(reserved), ";")
 }
 
 func (x *sheetExporter) exportMessager() error {
@@ -454,7 +586,8 @@ func (x *sheetExporter) exportMessager() error {
 	x.p.P("")
 
 	md := x.findMDFromGeneratedProtos(x.ws.Name)
-	x.assignFieldNumbers(x.ws.Fields, md)
+	reserved := x.assignFieldNumbers(x.ws.Fields, md)
+	x.printReserved(1, reserved)
 	// generate the fields
 	depth := 1
 	for _, field := range x.ws.Fields {
@@ -584,7 +717,8 @@ func (x *sheetExporter) exportField(depth int, field *internalpb.Field, prefix s
 			x.p.P(printer.Indent(depth+1), "option (buf.validate.message) = {", x.be.marshalToText(msgRules), "};")
 		}
 
-		x.assignFieldNumbers(field.Fields, oldMD)
+		reserved := x.assignFieldNumbers(field.Fields, oldMD)
+		x.printReserved(depth+1, reserved)
 		for _, subField := range field.Fields {
 			var nestedOldFD protoreflect.FieldDescriptor
 			if oldMD != nil {

--- a/internal/protogen/exporter_test.go
+++ b/internal/protogen/exporter_test.go
@@ -18,7 +18,10 @@ import (
 	"github.com/tableauio/tableau/proto/tableaupb/internalpb"
 	_ "github.com/tableauio/tableau/proto/tableaupb/unittestpb"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
@@ -671,6 +674,7 @@ func Test_sheetExporter_exportStruct(t *testing.T) {
 			want: `message Item {
   option (tableau.struct) = {name:"StructItem"};
 
+  reserved 2;
   uint32 id = 1 [(tableau.field) = {name:"ID"}];
   protoconf.FruitType fruit_type = 3 [(tableau.field) = {name:"FruitType"}];
 }
@@ -813,6 +817,7 @@ func Test_sheetExporter_exportUnion(t *testing.T) {
   }
 
   message Pvp {
+    reserved 2, 4;
     int32 type = 1 [(tableau.field) = {name:"Type"}];
     uint32 armor = 5 [(tableau.field) = {name:"Armor"}];
     int64 damage = 3 [(tableau.field) = {name:"Damage"}];
@@ -1019,6 +1024,7 @@ func Test_sheetExporter_exportMessager(t *testing.T) {
 			want: `message YamlScalarConf {
   option (tableau.worksheet) = {name:"YamlScalarConf"};
 
+  reserved 2, 9;
   uint32 id = 1 [(tableau.field) = {name:"ID"}];
   uint64 value = 3 [(tableau.field) = {name:"Value"}];
   int32 inserted_field = 10 [(tableau.field) = {name:"InsertedField"}];
@@ -1103,6 +1109,7 @@ func Test_sheetExporter_exportMessager(t *testing.T) {
 
   map<uint32, Activity> activity_map = 1 [(tableau.field) = {key:"ActivityID" layout:LAYOUT_VERTICAL}];
   message Activity {
+    reserved 2;
     uint32 activity_id = 1 [(tableau.field) = {name:"ActivityID"}];
     string activity_desc = 4 [(tableau.field) = {name:"ActivityDesc"}];
     map<uint32, Chapter> chapter_map = 3 [(tableau.field) = {key:"ChapterID" layout:LAYOUT_VERTICAL}];
@@ -1111,6 +1118,7 @@ func Test_sheetExporter_exportMessager(t *testing.T) {
       string chapter_name = 2 [(tableau.field) = {name:"ChapterName"}];
       repeated Section section_list = 3 [(tableau.field) = {layout:LAYOUT_VERTICAL}];
       message Section {
+        reserved 2;
         uint32 section_id = 1 [(tableau.field) = {name:"SectionID"}];
         string section_desc = 4 [(tableau.field) = {name:"SectionDesc"}];
         map<uint32, Reward> reward_map = 3 [(tableau.field) = {name:"Reward" key:"ID" layout:LAYOUT_HORIZONTAL}];
@@ -1133,6 +1141,223 @@ func Test_sheetExporter_exportMessager(t *testing.T) {
 				t.Errorf("sheetExporter.exportMessager() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.want, tt.x.p.String())
+		})
+	}
+}
+
+func Test_formatReservedNumbers(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int32
+		want string
+	}{
+		{name: "empty", in: nil, want: ""},
+		{name: "single", in: []int32{3}, want: "3"},
+		{name: "two-non-consecutive", in: []int32{2, 9}, want: "2, 9"},
+		{name: "consecutive-collapsed-to-range", in: []int32{2, 3, 4}, want: "2 to 4"},
+		{name: "mixed", in: []int32{2, 3, 4, 9}, want: "2 to 4, 9"},
+		{name: "multiple-ranges", in: []int32{1, 2, 5, 7, 8, 9, 12}, want: "1 to 2, 5, 7 to 9, 12"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatReservedNumbers(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// reservedRange describes a [start, end] inclusive reserved range used to
+// build a synthetic oldMD in Test_sheetExporter_assignFieldNumbers.
+type reservedRange struct{ start, end int32 }
+
+// buildOldMDWithReserved synthesizes a MessageDescriptor with the given
+// active fields (name -> number) and inclusive reserved ranges, so unit
+// tests for assignFieldNumbers can exercise oldMD shapes that don't exist
+// in the unittest .proto files (e.g., pre-existing reserved ranges, gaps
+// between active and reserved, etc.).
+func buildOldMDWithReserved(t *testing.T, fields map[string]int32, reserved []reservedRange) protoreflect.MessageDescriptor {
+	t.Helper()
+	msg := &descriptorpb.DescriptorProto{Name: proto.String("OldMsg")}
+	for name, num := range fields {
+		msg.Field = append(msg.Field, &descriptorpb.FieldDescriptorProto{
+			Name:   proto.String(name),
+			Number: proto.Int32(num),
+			Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+		})
+	}
+	for _, r := range reserved {
+		// FileDescriptorProto's reserved_range uses [start, end) end-exclusive.
+		msg.ReservedRange = append(msg.ReservedRange, &descriptorpb.DescriptorProto_ReservedRange{
+			Start: proto.Int32(r.start),
+			End:   proto.Int32(r.end + 1),
+		})
+	}
+	fdp := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("synthetic_oldmd.proto"),
+		Syntax:  proto.String("proto2"),
+		Package: proto.String("synthetic"),
+		MessageType: []*descriptorpb.DescriptorProto{msg},
+	}
+	fd, err := protodesc.NewFile(fdp, nil)
+	assert.NoError(t, err)
+	return fd.Messages().Get(0)
+}
+
+func Test_sheetExporter_assignFieldNumbers(t *testing.T) {
+	type fieldSpec struct {
+		name       string
+		wantNumber int32
+	}
+	tests := []struct {
+		name         string
+		oldFields    map[string]int32
+		oldReserved  []reservedRange
+		fields       []fieldSpec
+		wantReserved []int32
+	}{
+		{
+			// oldMD == nil: simply assign 1..N.
+			name: "no-old-md-assigns-from-1",
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "b", wantNumber: 2},
+				{name: "c", wantNumber: 3},
+			},
+			wantReserved: nil,
+		},
+		{
+			// All old fields kept, no addition: reuse old numbers.
+			name:      "all-old-fields-kept",
+			oldFields: map[string]int32{"a": 1, "b": 2},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "b", wantNumber: 2},
+			},
+			wantReserved: nil,
+		},
+		{
+			// New field appended: gets next number after max used.
+			name:      "new-field-appended",
+			oldFields: map[string]int32{"a": 1, "b": 2},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "b", wantNumber: 2},
+				{name: "c", wantNumber: 3},
+			},
+			wantReserved: nil,
+		},
+		{
+			// Field deleted (not reserved before): its number gets reserved.
+			name:      "old-field-deleted-becomes-reserved",
+			oldFields: map[string]int32{"a": 1, "b": 2, "c": 3},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "c", wantNumber: 3},
+			},
+			wantReserved: []int32{2},
+		},
+		{
+			// Scenario from user query: oldMD has active fields 1, 2 and a
+			// pre-existing `reserved 3`. A new field is added; it must NOT
+			// reuse 3 and instead start at 4.
+			name:        "preexisting-reserved-just-after-active",
+			oldFields:   map[string]int32{"a": 1, "b": 2},
+			oldReserved: []reservedRange{{3, 3}},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "b", wantNumber: 2},
+				{name: "c", wantNumber: 4},
+			},
+			wantReserved: []int32{3},
+		},
+		{
+			// Pre-existing reserved range that was previously declared by the
+			// user (declared higher than any active field). The new field must
+			// not collide with it; the gap below it is auto-reserved (we
+			// accept this behavior per project policy).
+			name:        "preexisting-reserved-higher-than-active",
+			oldFields:   map[string]int32{"a": 1},
+			oldReserved: []reservedRange{{5, 5}},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "newF", wantNumber: 6},
+			},
+			wantReserved: []int32{2, 3, 4, 5},
+		},
+		{
+			// Pre-existing reserved combined with a deletion in this round.
+			// All three sources of reservation must merge: pre-existing
+			// reserved (3), deleted field number (2), and survivors keep
+			// their own numbers; new field starts after max used.
+			name:        "preexisting-reserved-plus-delete",
+			oldFields:   map[string]int32{"a": 1, "b": 2, "c": 4},
+			oldReserved: []reservedRange{{3, 3}},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "c", wantNumber: 4},
+				{name: "newF", wantNumber: 5},
+			},
+			wantReserved: []int32{2, 3},
+		},
+		{
+			// Pre-existing CONSECUTIVE reserved range (declared as
+			// `reserved 2 to 4;`). Should be carried over verbatim and the
+			// new field assigned right after.
+			name:        "preexisting-reserved-consecutive-range",
+			oldFields:   map[string]int32{"a": 1},
+			oldReserved: []reservedRange{{2, 4}},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "newF", wantNumber: 5},
+			},
+			wantReserved: []int32{2, 3, 4},
+		},
+		{
+			// Gap in active fields (1, 2, 4) without any pre-existing
+			// reserved entry — most likely from an older tableau version
+			// that deleted field #3 without reserving it. The gap should
+			// be auto-reserved.
+			name:      "auto-reserve-gap-without-preexisting-reserved",
+			oldFields: map[string]int32{"a": 1, "b": 2, "c": 4},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "b", wantNumber: 2},
+				{name: "c", wantNumber: 4},
+				{name: "newF", wantNumber: 5},
+			},
+			wantReserved: []int32{3},
+		},
+		{
+			// Field rename should NOT keep the number: a renamed field is
+			// treated as "old deleted + new added".
+			name:      "field-rename-old-number-reserved-new-gets-next",
+			oldFields: map[string]int32{"a": 1, "b": 2},
+			fields: []fieldSpec{
+				{name: "a", wantNumber: 1},
+				{name: "b_renamed", wantNumber: 3},
+			},
+			wantReserved: []int32{2},
+		},
+	}
+
+	x := &sheetExporter{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var oldMD protoreflect.MessageDescriptor
+			if tt.oldFields != nil || tt.oldReserved != nil {
+				oldMD = buildOldMDWithReserved(t, tt.oldFields, tt.oldReserved)
+			}
+			pbFields := make([]*internalpb.Field, len(tt.fields))
+			for i, f := range tt.fields {
+				pbFields[i] = &internalpb.Field{Name: f.name}
+			}
+			gotReserved := x.assignFieldNumbers(pbFields, oldMD)
+			assert.Equal(t, tt.wantReserved, gotReserved, "reserved numbers mismatch")
+			for i, f := range tt.fields {
+				assert.Equal(t, f.wantNumber, pbFields[i].Number,
+					"field %q: want number %d, got %d", f.name, f.wantNumber, pbFields[i].Number)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- close #402 

### Background / Motivation

When Tableau regenerates `.proto` files from Excel workbooks, it previously re-assigned field numbers strictly from 1..N in declaration order. This broke wire-format compatibility in two ways:

1. **Reordering / inserting columns** silently reassigned field numbers of unchanged columns, breaking existing serialized data.
2. **Deleting columns** freed the corresponding numbers for reuse by future new columns, violating protobuf's golden rule "never reuse a deleted field number".

This PR makes regeneration **wire-compatible** by preserving old field numbers and emitting `reserved` statements as needed.

### What changed

`internal/protogen/exporter.go` — `sheetExporter.assignFieldNumbers`:

- **Stable numbers for surviving fields.** When an `oldMD` (previously generated `MessageDescriptor`) is available, fields whose `name` matches an existing field keep their old number, regardless of column order.
- **Reserve deleted fields.** Any field present in `oldMD` but no longer in the current sheet has its number added to a `reserved` set.
- **Carry over pre-existing reserved ranges.** Reserved ranges already declared in `oldMD` are preserved verbatim across regenerations.
- **Auto-reserve gaps.** Numbers in `[1, maxUsedNumber]` that are neither active nor already reserved are auto-reserved — this defends against older Tableau versions that deleted fields without reserving them.
- **Collision-free new numbers.** New fields get the next number strictly greater than any active-or-reserved number, so they never collide with a reserved entry.

Supporting pieces:

- New helper `formatReservedNumbers` collapses a sorted number list into the compact proto syntax (`2, 5, 7 to 9, 12`).
- New helper `sheetExporter.printReserved` emits a single `reserved …;` line at the correct indentation.
- The three call-sites (`exportStruct`, `exportUnion`, `exportMessager`, and the nested-message branch in `exportField`) now consume the returned reserved slice and print it.

### Tests

`internal/protogen/exporter_test.go`:

- New `Test_formatReservedNumbers` covers empty / single / non-consecutive / consecutive / mixed / multi-range formatting.
- New `Test_sheetExporter_assignFieldNumbers` uses `protodesc.NewFile` to synthesize `MessageDescriptor`s with arbitrary active fields and reserved ranges, covering 10 semantic scenarios:
  - `oldMD == nil` → sequential assignment from 1.
  - All old fields kept → reuse old numbers.
  - New field appended → next number after max used.
  - Deleted field → number becomes reserved.
  - Pre-existing `reserved N` right after active fields → new field skips it.
  - Pre-existing `reserved N` higher than all active fields → all gaps below are auto-reserved; new field starts after N.
  - Pre-existing reserved + deletion in the same round → merged correctly.
  - Pre-existing consecutive `reserved 2 to 4` → carried over verbatim.
  - Active-field gap (1, 2, 4) without pre-existing reserved → gap auto-reserved.
  - Field rename → old number reserved, new name gets next number.
- Existing `exportStruct` / `exportUnion` / `exportMessager` tests extended with `field-number-compatibility-*` sub-tests (insertion-in-the-middle, delete-and-add, sub-message nesting).

### Compatibility

- Wire-format compatible: no existing field number is ever moved or reused.
- Backward compatible with `.proto` files generated by older Tableau versions that left gaps without `reserved`: those gaps are now auto-reserved on the next regeneration.
- No public API change; behavior is gated on whether `oldMD` is discoverable (i.e., requires `PreserveFieldNumbers` + an existing generated proto in the registry), so fresh generations are unaffected.
