### PR TITLE
fix(confgen): dedup FileDescriptor in workbook index

### DIFF
--- a/internal/confgen/confgen.go
+++ b/internal/confgen/confgen.go
@@ -145,7 +145,7 @@ func (gen *Generator) GenWorkbook(bookSpecifiers ...string) error {
 		}
 		relCleanSlashPath := xfs.CleanSlashPath(bookName)
 		log.Debugf("convert relWorkbookPath to relCleanSlashPath: %s -> %s", bookName, relCleanSlashPath)
-		primaryBookInfo, ok := bookIndexes[relCleanSlashPath]
+		primaryBookInfo, ok := bookIndexes.get(relCleanSlashPath)
 		if !ok {
 			if gen.InputOpt.IgnoreUnknownWorkbook {
 				log.Debugf("primary workbook not found: %s, but IgnoreUnknownWorkbook is true, so just continue...", relCleanSlashPath)

--- a/internal/confgen/util.go
+++ b/internal/confgen/util.go
@@ -156,43 +156,61 @@ func parseBookSpecifier(bookSpecifier string) (bookName string, sheetName string
 	return xfs.Join(dir, tokens[0]), "", nil
 }
 
-// primaryBookInfo represents the primary workbook info.
+// bookIndex maps each workbook path (primary or secondary) to the proto
+// FileDescriptors associated with it. Wrapping the map in a struct gives
+// room to add fields (e.g. statistics, locks, derived caches) without
+// changing the public surface used by callers.
+type bookIndex struct {
+	books map[string]*primaryBookInfo
+}
+
+// newBookIndex returns an empty bookIndex ready to record entries via add.
+func newBookIndex() *bookIndex {
+	return &bookIndex{books: map[string]*primaryBookInfo{}}
+}
+
+// add records fd under bookName. Duplicate fds (same fd.Path()) are skipped,
+// so callers can safely add the same fd multiple times — this happens when
+// a Merger/Scatter glob resolves back to an already-indexed workbook, which
+// would otherwise cause GenWorkbook to run convert() twice for the same
+// (book, fd) pair.
+func (b *bookIndex) add(bookName string, fd protoreflect.FileDescriptor) {
+	info := b.books[bookName]
+	if info == nil {
+		info = &primaryBookInfo{}
+		b.books[bookName] = info
+	}
+	info.addFd(fd)
+}
+
+// get returns the primaryBookInfo recorded under bookName, or (nil, false)
+// if no entry exists.
+func (b *bookIndex) get(bookName string) (*primaryBookInfo, bool) {
+	info, ok := b.books[bookName]
+	return info, ok
+}
+
+// primaryBookInfo holds the FileDescriptors mapped to one workbook key in a bookIndex.
 type primaryBookInfo struct {
-	//  1. Due to Merger/Scatter, one workbook may relate to multiple primary workbooks.
-	//  2. One primary workbook may generate multiple proto files with different
-	// 	   messagers (e.g: full version with all columns and lite version with
-	// 	   fewer columns).
+	// fds can contain more than one descriptor because:
+	//   - Merger/Scatter: several primary workbooks may reference the same workbook.
+	//   - One workbook may be described by multiple proto files (e.g. lite + full variants).
 	fds []protoreflect.FileDescriptor
 }
 
-// appendUniqueFdByPath appends fd to fds, skipping if an entry with the
-// same fd.Path() already exists. Dedup is needed because Merger/Scatter
-// globs may resolve to an already-indexed workbook (e.g. a Scatter pattern
-// matching the primary workbook itself), which would otherwise cause
-// GenWorkbook to run convert() twice for the same (book, fd) pair.
-func appendUniqueFdByPath(fds []protoreflect.FileDescriptor, fd protoreflect.FileDescriptor) []protoreflect.FileDescriptor {
-	for _, existed := range fds {
+// addFd appends fd to p.fds, skipping if an entry with the same fd.Path() already exists.
+func (p *primaryBookInfo) addFd(fd protoreflect.FileDescriptor) {
+	for _, existed := range p.fds {
 		if existed.Path() == fd.Path() {
-			return fds
+			return
 		}
 	}
-	return append(fds, fd)
+	p.fds = append(p.fds, fd)
 }
 
 // buildWorkbookIndex builds all workbook names (includes primary and secondary) to primary workbook info indexes.
-func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirRewrites map[string]string, prFiles *protoregistry.Files) (bookIndexes map[string]*primaryBookInfo, err error) {
-	bookIndexes = map[string]*primaryBookInfo{} // init
-	// index records fd under bookName, deduped by fd.Path() to avoid
-	// scheduling convert() twice when Merger/Scatter globs resolve
-	// to an already-indexed workbook.
-	index := func(bookName string, fd protoreflect.FileDescriptor) {
-		info := bookIndexes[bookName]
-		if info == nil {
-			info = &primaryBookInfo{}
-			bookIndexes[bookName] = info
-		}
-		info.fds = appendUniqueFdByPath(info.fds, fd)
-	}
+func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirRewrites map[string]string, prFiles *protoregistry.Files) (bookIndexes *bookIndex, err error) {
+	bookIndexes = newBookIndex()
 	prFiles.RangeFilesByPackage(
 		protoreflect.FullName(protoPackage),
 		func(fd protoreflect.FileDescriptor) bool {
@@ -207,7 +225,7 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 
 			// add self: rewrite subdir
 			rewrittenBookName := xfs.RewriteSubdir(workbook.Name, subdirRewrites)
-			index(rewrittenBookName, fd)
+			bookIndexes.add(rewrittenBookName, fd)
 			// Merger/Scatter (only one can be set at once)
 			msgs := fd.Messages()
 			for i := 0; i < msgs.Len(); i++ {
@@ -228,7 +246,7 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 						return false
 					}
 					for relBookPath := range relBookPaths {
-						index(relBookPath, fd)
+						bookIndexes.add(relBookPath, fd)
 					}
 				}
 			}
@@ -240,7 +258,7 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 	}
 	// debugging
 	if log.LevelEnabled(zap.DebugLevel) {
-		for k, v := range bookIndexes {
+		for k, v := range bookIndexes.books {
 			for _, fd := range v.fds {
 				_, workbook := ParseFileOptions(fd)
 				log.Debugf("primary book index: %s -> %s (%s)", k, workbook.GetName(), fd.Path())

--- a/internal/confgen/util.go
+++ b/internal/confgen/util.go
@@ -165,13 +165,12 @@ type primaryBookInfo struct {
 	fds []protoreflect.FileDescriptor
 }
 
-// appendDedupedFd appends fd to fds if no existing entry has the same fd.Path().
-// Identity is keyed by fd.Path() because a single proto file may be visited
-// multiple times via Merger/Scatter glob results that resolve to a workbook
-// already indexed (e.g. a Scatter pattern globbing the primary workbook
-// itself). Without this dedup, GenWorkbook would schedule convert() for the
-// same (book, fd) pair more than once, producing duplicated output and logs.
-func appendDedupedFd(fds []protoreflect.FileDescriptor, fd protoreflect.FileDescriptor) []protoreflect.FileDescriptor {
+// appendUniqueFdByPath appends fd to fds, skipping if an entry with the
+// same fd.Path() already exists. Dedup is needed because Merger/Scatter
+// globs may resolve to an already-indexed workbook (e.g. a Scatter pattern
+// matching the primary workbook itself), which would otherwise cause
+// GenWorkbook to run convert() twice for the same (book, fd) pair.
+func appendUniqueFdByPath(fds []protoreflect.FileDescriptor, fd protoreflect.FileDescriptor) []protoreflect.FileDescriptor {
 	for _, existed := range fds {
 		if existed.Path() == fd.Path() {
 			return fds
@@ -183,6 +182,17 @@ func appendDedupedFd(fds []protoreflect.FileDescriptor, fd protoreflect.FileDesc
 // buildWorkbookIndex builds all workbook names (includes primary and secondary) to primary workbook info indexes.
 func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirRewrites map[string]string, prFiles *protoregistry.Files) (bookIndexes map[string]*primaryBookInfo, err error) {
 	bookIndexes = map[string]*primaryBookInfo{} // init
+	// index records fd under bookName, deduped by fd.Path() to avoid
+	// scheduling convert() twice when Merger/Scatter globs resolve
+	// to an already-indexed workbook.
+	index := func(bookName string, fd protoreflect.FileDescriptor) {
+		info := bookIndexes[bookName]
+		if info == nil {
+			info = &primaryBookInfo{}
+			bookIndexes[bookName] = info
+		}
+		info.fds = appendUniqueFdByPath(info.fds, fd)
+	}
 	prFiles.RangeFilesByPackage(
 		protoreflect.FullName(protoPackage),
 		func(fd protoreflect.FileDescriptor) bool {
@@ -194,21 +204,10 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 			if !xfs.HasSubdirPrefix(workbook.Name, subdirs) {
 				return true
 			}
-			// addFd appends fd to bookIndexes[bookName].fds, deduped by fd.Path().
-			// This avoids scheduling convert() multiple times for the same (book, fd)
-			// pair when a Merger/Scatter specifier globs to a workbook that is
-			// already indexed (most commonly: the primary workbook itself).
-			addFd := func(bookName string, fd protoreflect.FileDescriptor) {
-				info := bookIndexes[bookName]
-				if info == nil {
-					info = &primaryBookInfo{}
-					bookIndexes[bookName] = info
-				}
-				info.fds = appendDedupedFd(info.fds, fd)
-			}
+
 			// add self: rewrite subdir
 			rewrittenBookName := xfs.RewriteSubdir(workbook.Name, subdirRewrites)
-			addFd(rewrittenBookName, fd)
+			index(rewrittenBookName, fd)
 			// Merger/Scatter (only one can be set at once)
 			msgs := fd.Messages()
 			for i := 0; i < msgs.Len(); i++ {
@@ -229,7 +228,7 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 						return false
 					}
 					for relBookPath := range relBookPaths {
-						addFd(relBookPath, fd)
+						index(relBookPath, fd)
 					}
 				}
 			}

--- a/internal/confgen/util.go
+++ b/internal/confgen/util.go
@@ -165,6 +165,21 @@ type primaryBookInfo struct {
 	fds []protoreflect.FileDescriptor
 }
 
+// appendDedupedFd appends fd to fds if no existing entry has the same fd.Path().
+// Identity is keyed by fd.Path() because a single proto file may be visited
+// multiple times via Merger/Scatter glob results that resolve to a workbook
+// already indexed (e.g. a Scatter pattern globbing the primary workbook
+// itself). Without this dedup, GenWorkbook would schedule convert() for the
+// same (book, fd) pair more than once, producing duplicated output and logs.
+func appendDedupedFd(fds []protoreflect.FileDescriptor, fd protoreflect.FileDescriptor) []protoreflect.FileDescriptor {
+	for _, existed := range fds {
+		if existed.Path() == fd.Path() {
+			return fds
+		}
+	}
+	return append(fds, fd)
+}
+
 // buildWorkbookIndex builds all workbook names (includes primary and secondary) to primary workbook info indexes.
 func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirRewrites map[string]string, prFiles *protoregistry.Files) (bookIndexes map[string]*primaryBookInfo, err error) {
 	bookIndexes = map[string]*primaryBookInfo{} // init
@@ -179,12 +194,21 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 			if !xfs.HasSubdirPrefix(workbook.Name, subdirs) {
 				return true
 			}
+			// addFd appends fd to bookIndexes[bookName].fds, deduped by fd.Path().
+			// This avoids scheduling convert() multiple times for the same (book, fd)
+			// pair when a Merger/Scatter specifier globs to a workbook that is
+			// already indexed (most commonly: the primary workbook itself).
+			addFd := func(bookName string, fd protoreflect.FileDescriptor) {
+				info := bookIndexes[bookName]
+				if info == nil {
+					info = &primaryBookInfo{}
+					bookIndexes[bookName] = info
+				}
+				info.fds = appendDedupedFd(info.fds, fd)
+			}
 			// add self: rewrite subdir
 			rewrittenBookName := xfs.RewriteSubdir(workbook.Name, subdirRewrites)
-			if bookIndexes[rewrittenBookName] == nil {
-				bookIndexes[rewrittenBookName] = &primaryBookInfo{}
-			}
-			bookIndexes[rewrittenBookName].fds = append(bookIndexes[rewrittenBookName].fds, fd)
+			addFd(rewrittenBookName, fd)
 			// Merger/Scatter (only one can be set at once)
 			msgs := fd.Messages()
 			for i := 0; i < msgs.Len(); i++ {
@@ -205,10 +229,7 @@ func buildWorkbookIndex(protoPackage, inputDir string, subdirs []string, subdirR
 						return false
 					}
 					for relBookPath := range relBookPaths {
-						if bookIndexes[relBookPath] == nil {
-							bookIndexes[relBookPath] = &primaryBookInfo{}
-						}
-						bookIndexes[relBookPath].fds = append(bookIndexes[relBookPath].fds, fd)
+						addFd(relBookPath, fd)
 					}
 				}
 			}

--- a/internal/confgen/util_test.go
+++ b/internal/confgen/util_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-func Test_appendDedupedFd(t *testing.T) {
+func Test_appendUniqueFdByPath(t *testing.T) {
 	// Two different proto files give us two FileDescriptors with different
 	// Path() values. Reusing the same FileDescriptor instance under different
 	// variable names still counts as the same identity (same Path()).
@@ -61,13 +61,13 @@ func Test_appendDedupedFd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := appendDedupedFd(tt.initial, tt.toAppend)
+			got := appendUniqueFdByPath(tt.initial, tt.toAppend)
 			gotPaths := make([]string, 0, len(got))
 			for _, fd := range got {
 				gotPaths = append(gotPaths, fd.Path())
 			}
 			if !reflect.DeepEqual(gotPaths, tt.wantPaths) {
-				t.Errorf("appendDedupedFd() paths = %v, want %v", gotPaths, tt.wantPaths)
+				t.Errorf("appendUniqueFdByPath() paths = %v, want %v", gotPaths, tt.wantPaths)
 			}
 		})
 	}

--- a/internal/confgen/util_test.go
+++ b/internal/confgen/util_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-func Test_appendUniqueFdByPath(t *testing.T) {
+func Test_primaryBookInfo_addFd(t *testing.T) {
 	// Two different proto files give us two FileDescriptors with different
 	// Path() values. Reusing the same FileDescriptor instance under different
 	// variable names still counts as the same identity (same Path()).
@@ -27,47 +27,48 @@ func Test_appendUniqueFdByPath(t *testing.T) {
 	tests := []struct {
 		name      string
 		initial   []protoreflect.FileDescriptor
-		toAppend  protoreflect.FileDescriptor
+		toAdd     protoreflect.FileDescriptor
 		wantPaths []string
 	}{
 		{
-			name:      "append to empty",
+			name:      "add to empty",
 			initial:   nil,
-			toAppend:  fdA,
+			toAdd:     fdA,
 			wantPaths: []string{fdA.Path()},
 		},
 		{
-			name:      "append distinct fd",
+			name:      "add distinct fd",
 			initial:   []protoreflect.FileDescriptor{fdA},
-			toAppend:  fdB,
+			toAdd:     fdB,
 			wantPaths: []string{fdA.Path(), fdB.Path()},
 		},
 		{
-			// Core regression: same fd appended twice must NOT duplicate.
+			// Core regression: same fd added twice must NOT duplicate.
 			// This is the bug behind the duplicated parsing/scatter/export
 			// logs when a Scatter specifier globs to the primary workbook
 			// itself, causing addFd() to be called twice with the same fd.
 			name:      "skip duplicate fd by Path",
 			initial:   []protoreflect.FileDescriptor{fdA},
-			toAppend:  fdA,
+			toAdd:     fdA,
 			wantPaths: []string{fdA.Path()},
 		},
 		{
 			name:      "skip duplicate among many",
 			initial:   []protoreflect.FileDescriptor{fdA, fdB},
-			toAppend:  fdB,
+			toAdd:     fdB,
 			wantPaths: []string{fdA.Path(), fdB.Path()},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := appendUniqueFdByPath(tt.initial, tt.toAppend)
-			gotPaths := make([]string, 0, len(got))
-			for _, fd := range got {
+			p := &primaryBookInfo{fds: tt.initial}
+			p.addFd(tt.toAdd)
+			gotPaths := make([]string, 0, len(p.fds))
+			for _, fd := range p.fds {
 				gotPaths = append(gotPaths, fd.Path())
 			}
 			if !reflect.DeepEqual(gotPaths, tt.wantPaths) {
-				t.Errorf("appendUniqueFdByPath() paths = %v, want %v", gotPaths, tt.wantPaths)
+				t.Errorf("addFd() paths = %v, want %v", gotPaths, tt.wantPaths)
 			}
 		})
 	}

--- a/internal/confgen/util_test.go
+++ b/internal/confgen/util_test.go
@@ -14,6 +14,65 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+func Test_appendDedupedFd(t *testing.T) {
+	// Two different proto files give us two FileDescriptors with different
+	// Path() values. Reusing the same FileDescriptor instance under different
+	// variable names still counts as the same identity (same Path()).
+	fdA := (&unittestpb.ItemConf{}).ProtoReflect().Descriptor().ParentFile()
+	fdB := (&unittestpb.Item{}).ProtoReflect().Descriptor().ParentFile()
+	if fdA.Path() == fdB.Path() {
+		t.Fatalf("test prerequisite broken: fdA and fdB share the same Path() %q", fdA.Path())
+	}
+
+	tests := []struct {
+		name      string
+		initial   []protoreflect.FileDescriptor
+		toAppend  protoreflect.FileDescriptor
+		wantPaths []string
+	}{
+		{
+			name:      "append to empty",
+			initial:   nil,
+			toAppend:  fdA,
+			wantPaths: []string{fdA.Path()},
+		},
+		{
+			name:      "append distinct fd",
+			initial:   []protoreflect.FileDescriptor{fdA},
+			toAppend:  fdB,
+			wantPaths: []string{fdA.Path(), fdB.Path()},
+		},
+		{
+			// Core regression: same fd appended twice must NOT duplicate.
+			// This is the bug behind the duplicated parsing/scatter/export
+			// logs when a Scatter specifier globs to the primary workbook
+			// itself, causing addFd() to be called twice with the same fd.
+			name:      "skip duplicate fd by Path",
+			initial:   []protoreflect.FileDescriptor{fdA},
+			toAppend:  fdA,
+			wantPaths: []string{fdA.Path()},
+		},
+		{
+			name:      "skip duplicate among many",
+			initial:   []protoreflect.FileDescriptor{fdA, fdB},
+			toAppend:  fdB,
+			wantPaths: []string{fdA.Path(), fdB.Path()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendDedupedFd(tt.initial, tt.toAppend)
+			gotPaths := make([]string, 0, len(got))
+			for _, fd := range got {
+				gotPaths = append(gotPaths, fd.Path())
+			}
+			if !reflect.DeepEqual(gotPaths, tt.wantPaths) {
+				t.Errorf("appendDedupedFd() paths = %v, want %v", gotPaths, tt.wantPaths)
+			}
+		})
+	}
+}
+
 func Test_parseBookSpecifier(t *testing.T) {
 	type args struct {
 		bookSpecifier string


### PR DESCRIPTION
## Summary

`buildWorkbookIndex` could list the same `FileDescriptor` twice under one workbook key, causing `GenWorkbook` to schedule `convert()` twice for the same `(book, fd)` pair. Symptom: every output file written twice, every `parsing sheet` / `scatter sheet` / `generated conf` log line printed twice.

## Root cause

In `internal/confgen/util.go`, `buildWorkbookIndex` records `fd` against `bookIndexes[<book>]` in two places:

1. **add-self**: under the primary workbook path.
2. **Merger/Scatter loop**: under each path returned by `importer.ResolveSheetSpecifier`.

When a `scatter` specifier globs back to the workbook it lives in (a common pattern, e.g. `scatter: "Foo.xlsx#FooConf*"`), step 2 re-records the same `fd` already added by step 1. `GenWorkbook` then iterates the slice and schedules `convert()` per entry — duplicates ran twice.

## Fix

Make dedup an invariant of the index type rather than caller discipline. The previously bare `map[string]*primaryBookInfo` is now wrapped in a `bookIndex` struct, and the per-key append goes through a method that skips entries with the same `fd.Path()`:

```go
type bookIndex struct {
    books map[string]*primaryBookInfo
}

func (b *bookIndex) add(bookName string, fd protoreflect.FileDescriptor) {
    info := b.books[bookName]
    if info == nil {
        info = &primaryBookInfo{}
        b.books[bookName] = info
    }
    info.addFd(fd)
}

func (p *primaryBookInfo) addFd(fd protoreflect.FileDescriptor) {
    for _, existed := range p.fds {
        if existed.Path() == fd.Path() {
            return
        }
    }
    p.fds = append(p.fds, fd)
}
```

`buildWorkbookIndex` routes both append sites (add-self and the Merger/Scatter loop) through `bookIndexes.add(...)`, so a workbook key can never end up with the same `fd` listed twice — regardless of how many specifiers happen to glob to the same path.

`fd.Path()` is the right identity key here: it is stable across `RangeFilesByPackage` iterations and naturally distinguishes the legitimate case of two different proto files describing the same workbook (e.g. lite + full variants).

Wrapping the map in a struct also leaves room for future additions (locks, statistics, derived caches) without touching callers.

## Test

`Test_primaryBookInfo_addFd` in `internal/confgen/util_test.go` — table-driven, 4 cases:

- add to empty
- add a distinct fd (different `Path()`)
- **skip duplicate fd by Path** — the regression case
- skip duplicate among many

The two distinct fds come from `unittestpb.ItemConf` (`unittest.proto`) and `unittestpb.Item` (`common.proto`), with an explicit precondition assert that their `Path()` values differ — so the test stays meaningful even if those proto files are reorganized later.

Existing `internal/confgen` tests continue to pass, including `-race`.