### PR TITLE
ci(buf): only sync top-level release tags to BSR

### DIFF
--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -1,6 +1,14 @@
 name: Buf CI
 on:
   push:
+    branches: ['**']
+    # Only top-level release tags (vX.Y.Z[-suffix]) should be synced to BSR.
+    # Submodule tags such as `cmd/tableauc/vX.Y.Z` (consumed by release.yml)
+    # must NOT trigger this workflow, otherwise buf-action would push them
+    # to BSR as well.
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   delete:


### PR DESCRIPTION
## Problem

This repo tags releases at two levels:

- top-level: `vX.Y.Z` (the library / proto module release).
- submodule: `cmd/tableauc/vX.Y.Z` (consumed by `release.yml` to build
  the `tableauc` binary archives).

The previous `buf-ci.yml` had an unfiltered `push:` trigger, so **every**
pushed tag, including `cmd/tableauc/vX.Y.Z`, ran `bufbuild/buf-action`
and ended up on BSR as a separate tag. `buf-action` itself has no
tag-name filter, so this had to be solved at the workflow trigger layer.

<img width="1675" height="459" alt="image" src="https://github.com/user-attachments/assets/9e046af4-bb83-403c-b1f7-38aedca008e9" />


## Fix

Use a tag whitelist on the `push` trigger so only top-level release
tags reach `buf-action`:

```yaml
on:
  push:
    branches: ['**']
    tags:
      - 'v[0-9]+.[0-9]+.[0-9]+'
      - 'v[0-9]+.[0-9]+.[0-9]+-*'
