### PR TITLE
ci: drop cmd/tableauc release tag scheme and bump buf-action

### DIFF
--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -2,13 +2,6 @@ name: Buf CI
 on:
   push:
     branches: ['**']
-    # Only top-level release tags (vX.Y.Z[-suffix]) should be synced to BSR.
-    # Submodule tags such as `cmd/tableauc/vX.Y.Z` (consumed by release.yml)
-    # must NOT trigger this workflow, otherwise buf-action would push them
-    # to BSR as well.
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   delete:
@@ -16,9 +9,12 @@ jobs:
   buf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: bufbuild/buf-action@v1
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Buf CI
+        uses: bufbuild/buf-action@v1
         with:
-          version: "1.69.0"
+          version: 1.69.0
           token: ${{ secrets.BUF_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Buf
         uses: bufbuild/buf-action@v1
         with:
-          version: 1.67.0
+          version: 1.69.0
           setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   release:
-    name: Release cmd/tableauc
+    name: Release tableauc
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name, 'cmd/tableauc/')
+    # Only run for top-level release tags like `vX.Y.Z` (optionally with a suffix).
+    if: startsWith(github.event.release.tag_name, 'v')
     strategy:
       matrix:
         goos: [linux, darwin, windows]
@@ -30,9 +31,7 @@ jobs:
           go-version: "1.24.x"
 
       - name: Download dependencies
-        run: |
-          cd cmd/tableauc
-          go mod download
+        run: go mod download
 
       - name: Prepare build directory
         run: |
@@ -52,9 +51,11 @@ jobs:
       - name: Create package
         id: package
         run: |
-          PACKAGE_NAME=tableauc.${GITHUB_REF#refs/tags/cmd/tableauc/}.${{ matrix.goos }}.${{ matrix.goarch }}.tar.gz
+          # Strip the leading `refs/tags/` so that a tag like `v0.16.1`
+          # produces a package name `tableauc.v0.16.1.<goos>.<goarch>.tar.gz`.
+          PACKAGE_NAME=tableauc.${GITHUB_REF#refs/tags/}.${{ matrix.goos }}.${{ matrix.goarch }}.tar.gz
           tar -czvf $PACKAGE_NAME -C build .
-          echo ::set-output name=name::${PACKAGE_NAME}
+          echo "name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload asset
         uses: actions/upload-release-asset@v1

--- a/proto/tableau/protobuf/tableau.proto
+++ b/proto/tableau/protobuf/tableau.proto
@@ -246,11 +246,11 @@ message WorksheetOptions {
   // Different kvs must be seperated by ',' and one key value must be seperated
   // by ':'. If one key doesn't exist in map, it means that this loader option
   // is supported in all languages. Valid values are all combinations of "cpp",
-  // "go" and "csharp" with ' ' as seperator.
+  // "go", "csharp" and "ts" with ' ' as seperator.
   //
   // Examples:
-  //  - OrderedMap:cpp,Index:cpp go // ordered map supported in cpp, index
-  //    supported in cpp and go
+  //  - OrderedMap:cpp,Index:cpp go ts // ordered map supported in cpp, index
+  //    supported in cpp, go and ts
   //  - OrderedMap:cpp // ordered map supported in cpp, index supported in all
   //    languages
   map<string, string> lang_options = 52;

--- a/proto/tableaupb/tableau.pb.go
+++ b/proto/tableaupb/tableau.pb.go
@@ -955,11 +955,11 @@ type WorksheetOptions struct {
 	// Different kvs must be seperated by ',' and one key value must be seperated
 	// by ':'. If one key doesn't exist in map, it means that this loader option
 	// is supported in all languages. Valid values are all combinations of "cpp",
-	// "go" and "csharp" with ' ' as seperator.
+	// "go", "csharp" and "ts" with ' ' as seperator.
 	//
 	// Examples:
-	//   - OrderedMap:cpp,Index:cpp go // ordered map supported in cpp, index
-	//     supported in cpp and go
+	//   - OrderedMap:cpp,Index:cpp go ts // ordered map supported in cpp, index
+	//     supported in cpp, go and ts
 	//   - OrderedMap:cpp // ordered map supported in cpp, index supported in all
 	//     languages
 	LangOptions map[string]string `protobuf:"bytes,52,rep,name=lang_options,json=langOptions,proto3" json:"lang_options,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`


### PR DESCRIPTION
## Background

Historically each release required pushing **two** tags pointing at the same commit:

- `vX.Y.Z` — the root module tag.
- `cmd/tableauc/vX.Y.Z` — required when `cmd/tableauc/` had its own `go.mod`.

The submodule `go.mod` was removed back in #181 (since v0.12.1), so `cmd/tableauc` is now just a regular sub-package of the root module `github.com/tableauio/tableau`. Users install it via `go install github.com/tableauio/tableau/cmd/tableauc@vX.Y.Z`, which resolves against the root tag — the `cmd/tableauc/vX.Y.Z` tag has had no effect on Go tooling since.

The only remaining consumer of `cmd/tableauc/*` was `release.yml`, where it was used as the workflow trigger and as part of the asset filename.

## Why this matters

Keeping the obsolete tag was actively harmful. When releasing v0.16.1, both tags were pushed to the same commit. Even though `buf-ci.yml` had filters specifically excluding `cmd/tableauc/*` from `push.tags`, the workflow still ran (triggered by the root `vX.Y.Z` tag), and `buf push --git-metadata` collects **all** refs pointing at HEAD. As a result `cmd/tableauc/v0.16.1` ended up published as a BSR label on `buf.build/tableauio/tableau`, polluting the module's label list.

## Changes

### `release.yml`
- Trigger on top-level `vX.Y.Z` release tags instead of `cmd/tableauc/*`.
- Drop the leading `cd cmd/tableauc` from the `Download dependencies` step (no submodule `go.mod` to download against).
- Asset filename now derives from the root tag, e.g. `tableauc.v0.16.1.linux.amd64.tar.gz` (consistent with the historical naming style).
- Replace the deprecated `::set-output` syntax with `$GITHUB_OUTPUT`.

### `buf-ci.yml`
- Remove the `push.tags` allowlist that existed solely to keep `cmd/tableauc/*` out of buf-action runs — no longer needed.
- Add step names; unquote `version: 1.69.0` for consistency.

### `lint.yml`
- Bump `bufbuild/buf-action` to `1.69.0` to match `buf-ci.yml`.

## Release process going forward

Only the root tag is needed:

```bash
git tag v0.16.2
git push origin master v0.16.2
# Then publish a Release on GitHub against v0.16.2.
