### PR TITLE
feat(protogen): detect enum/union Number-column collisions and attach book/sheet name to single-mode errors

### DIFF
--- a/internal/protogen/protogen.go
+++ b/internal/protogen/protogen.go
@@ -553,7 +553,9 @@ func (gen *Generator) convertTableSheet(bp *tableParser, bookCollector *xerrors.
 		} else {
 			worksheets, err := gen.parseSpecialSheetMode(ws.Options.Mode, ws, sheet, debugBookName, debugSheetName, sheetCollector)
 			if err != nil {
-				return sheetCollector.Collect(err)
+				return sheetCollector.Collect(xerrors.WrapKV(err,
+					xerrors.KeyBookName, debugBookName,
+					xerrors.KeySheetName, debugSheetName))
 			}
 			// append parsed sheets to workbook
 			bp.wb.Worksheets = append(bp.wb.Worksheets, worksheets...)

--- a/internal/protogen/sheet_mode.go
+++ b/internal/protogen/sheet_mode.go
@@ -63,10 +63,18 @@ func parseEnumType(ws *internalpb.Worksheet, sheet *book.Sheet, parser book.Shee
 		return err
 	}
 	prefix := strcase.FromContext(gen.ctx).ToScreamingSnake(ws.Name) + "_"
-	for i, value := range desc.Values {
-		number := int32(i + 1)
+
+	usedNumbers := make(map[int32]struct{}, len(desc.Values))
+	for _, value := range desc.Values {
 		if value.Number != nil {
-			number = value.GetNumber()
+			usedNumbers[*value.Number] = struct{}{}
+		}
+	}
+
+	for i, value := range desc.Values {
+		number, err := resolveFieldNumber(i, value.Number, usedNumbers, "enum", value.Name)
+		if err != nil {
+			return err
 		}
 		name := value.Name
 		if gen.OutputOpt.EnumValueWithPrefix && !strings.HasPrefix(name, prefix) {
@@ -80,6 +88,39 @@ func parseEnumType(ws *internalpb.Worksheet, sheet *book.Sheet, parser book.Shee
 		ws.Fields = append(ws.Fields, field)
 	}
 	return nil
+}
+
+// resolveFieldNumber computes the proto field number for one row of an
+// enum/union value table whose "Number" column is optional.
+//
+// Semantics (shared by parseEnumType and parseUnionType):
+//   - If the row sets Number explicitly, use it as-is. Uniqueness across
+//     explicitly-set values is already enforced by the "unique: true" prop on
+//     the descriptor's number field, so no extra check is needed here.
+//   - Otherwise fall back to i+1 (the row's 0-based index in desc.Values plus
+//     one). This preserves the legacy "auto-numbered 1..N" behavior when no
+//     row sets Number at all - in that case usedNumbers is empty and the
+//     collision check is a no-op, keeping byte-for-byte compatibility with the
+//     previous implementation.
+//   - When some rows set Number and others leave it blank, the i+1 fallback
+//     may collide with an explicitly-set value on another row. usedNumbers
+//     must contain all explicitly-set values; on collision we surface an
+//     error rather than silently emitting duplicate proto field numbers
+//     (which would in turn produce duplicate generated enum values).
+//
+// kind is a short noun ("enum" or "union") used only in the error message.
+func resolveFieldNumber(i int, explicit *int32, usedNumbers map[int32]struct{}, kind, name string) (int32, error) {
+	if explicit != nil {
+		return *explicit, nil
+	}
+	number := int32(i + 1)
+	if _, dup := usedNumbers[number]; dup {
+		return 0, xerrors.Newf(
+			"%s value %q (row index %d) has empty Number column, but the fallback value %d is already taken by another row's explicit Number. "+
+				"Either fill in the Number column for this row, or leave Number blank for all rows",
+			kind, strings.TrimSpace(name), i, number)
+	}
+	return number, nil
 }
 
 func isStructTypeBlockHeader(cols []string) bool {
@@ -295,8 +336,15 @@ func parseUnionType(ws *internalpb.Worksheet, sheet *book.Sheet, parser book.She
 	bp := newTableParser("union-fields", "", "", gen)
 	t := sheet.Tabler()
 
+	usedNumbers := make(map[int32]struct{}, len(desc.Values))
+	for _, value := range desc.Values {
+		if value.Number != nil {
+			usedNumbers[*value.Number] = struct{}{}
+		}
+	}
+
 	for i, value := range desc.Values {
-		field, err := newUnionField(i, value, gen, sheet.Name)
+		field, err := newUnionField(i, value, gen, usedNumbers)
 		if err != nil {
 			return err
 		}
@@ -309,11 +357,13 @@ func parseUnionType(ws *internalpb.Worksheet, sheet *book.Sheet, parser book.She
 }
 
 // newUnionField builds the top-level Field for a single union value, resolving
-// its optional type descriptor when a type string is present.
-func newUnionField(i int, value *internalpb.UnionDescriptor_Value, gen *Generator, sheetName string) (*internalpb.Field, error) {
-	number := int32(i + 1)
-	if value.Number != nil {
-		number = *value.Number
+// its optional type descriptor when a type string is present. See
+// resolveFieldNumber for the Number-column resolution semantics shared with
+// parseEnumType.
+func newUnionField(i int, value *internalpb.UnionDescriptor_Value, gen *Generator, usedNumbers map[int32]struct{}) (*internalpb.Field, error) {
+	number, err := resolveFieldNumber(i, value.Number, usedNumbers, "union", value.Name)
+	if err != nil {
+		return nil, err
 	}
 	field := &internalpb.Field{
 		Number: number,
@@ -323,7 +373,7 @@ func newUnionField(i int, value *internalpb.UnionDescriptor_Value, gen *Generato
 	if typ := strings.TrimSpace(value.Type); typ != "" {
 		typeDesc, err := parseTypeDescriptor(gen.typeInfos, typ)
 		if err != nil {
-			return nil, xerrors.Wrapf(err, "failed to parse union type %s of sheet: %s", typ, sheetName)
+			return nil, xerrors.Wrapf(err, "failed to parse union type %s", typ)
 		}
 		field.Type = typeDesc.Name
 		field.FullType = typeDesc.FullName

--- a/internal/protogen/sheet_mode_test.go
+++ b/internal/protogen/sheet_mode_test.go
@@ -1,9 +1,11 @@
 package protogen
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/tableauio/tableau/internal/importer/book"
+	"github.com/tableauio/tableau/proto/tableaupb/internalpb"
 )
 
 func TestVerticalPositioner_Position(t *testing.T) {
@@ -507,4 +509,194 @@ func TestBasePositioner_ColIndex(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveFieldNumber covers the Number-column resolution rules shared by
+// parseEnumType and parseUnionType. It exercises resolveFieldNumber directly
+// (the shared helper) so the same guarantees are pinned for both call sites:
+//   - When no row sets Number, the legacy "1, 2, 3, ..., N" fallback applies
+//     (regression guard for byte-for-byte backward compatibility).
+//   - When every row sets Number explicitly, the explicit values are used and
+//     the i+1 fallback is unreachable.
+//   - When some rows set Number and others leave it blank, the i+1 fallback
+//     on a blank row must detect collisions with another row's explicit
+//     Number and surface an error rather than silently emitting duplicate
+//     proto field numbers.
+func TestResolveFieldNumber(t *testing.T) {
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	type valueRow struct {
+		name   string
+		number *int32
+	}
+
+	collect := func(values []valueRow) map[int32]struct{} {
+		used := make(map[int32]struct{}, len(values))
+		for _, v := range values {
+			if v.number != nil {
+				used[*v.number] = struct{}{}
+			}
+		}
+		return used
+	}
+
+	t.Run("all-empty-preserves-legacy-1..N", func(t *testing.T) {
+		values := []valueRow{
+			{name: "V1"},
+			{name: "V2"},
+			{name: "V3"},
+		}
+		used := collect(values)
+		wantNumbers := []int32{1, 2, 3}
+		for i, v := range values {
+			got, err := resolveFieldNumber(i, v.number, used, "enum", v.name)
+			if err != nil {
+				t.Fatalf("i=%d unexpected error: %v", i, err)
+			}
+			if got != wantNumbers[i] {
+				t.Errorf("i=%d got %d, want %d", i, got, wantNumbers[i])
+			}
+		}
+	})
+
+	t.Run("all-explicit-uses-explicit-values", func(t *testing.T) {
+		values := []valueRow{
+			{name: "V1", number: int32Ptr(10)},
+			{name: "V2", number: int32Ptr(20)},
+			{name: "V3", number: int32Ptr(30)},
+		}
+		used := collect(values)
+		wantNumbers := []int32{10, 20, 30}
+		for i, v := range values {
+			got, err := resolveFieldNumber(i, v.number, used, "union", v.name)
+			if err != nil {
+				t.Fatalf("i=%d unexpected error: %v", i, err)
+			}
+			if got != wantNumbers[i] {
+				t.Errorf("i=%d got %d, want %d", i, got, wantNumbers[i])
+			}
+		}
+	})
+
+	t.Run("mixed-no-collision-uses-fallback", func(t *testing.T) {
+		// Explicit Number values are 10, 30; the blank rows fall back to i+1
+		// (2 and 4) which don't collide.
+		values := []valueRow{
+			{name: "V1", number: int32Ptr(10)},
+			{name: "V2"}, // i=1, fallback 2
+			{name: "V3", number: int32Ptr(30)},
+			{name: "V4"}, // i=3, fallback 4
+		}
+		used := collect(values)
+		wantNumbers := []int32{10, 2, 30, 4}
+		for i, v := range values {
+			got, err := resolveFieldNumber(i, v.number, used, "enum", v.name)
+			if err != nil {
+				t.Fatalf("i=%d unexpected error: %v", i, err)
+			}
+			if got != wantNumbers[i] {
+				t.Errorf("i=%d got %d, want %d", i, got, wantNumbers[i])
+			}
+		}
+	})
+
+	t.Run("mixed-collision-returns-error", func(t *testing.T) {
+		// V1 explicitly claims Number=3. V2 is blank (fallback 2, fine). V3 is
+		// blank too and its i+1 fallback is 3, which collides with V1. The
+		// natural for-range iteration must succeed for V1/V2 and fail on V3.
+		values := []valueRow{
+			{name: "V1", number: int32Ptr(3)},
+			{name: "V2"}, // i=1, fallback 2 - ok
+			{name: "V3"}, // i=2, fallback 3 - collides with V1
+		}
+		used := collect(values)
+		var errs []error
+		for i, v := range values {
+			_, err := resolveFieldNumber(i, v.number, used, "union", v.name)
+			errs = append(errs, err)
+		}
+		if errs[0] != nil {
+			t.Fatalf("V1 should resolve cleanly, got: %v", errs[0])
+		}
+		if errs[1] != nil {
+			t.Fatalf("V2 should resolve cleanly (fallback 2), got: %v", errs[1])
+		}
+		if errs[2] == nil {
+			t.Fatal("V3 should fail on i+1 fallback collision with V1's explicit Number, got nil")
+		}
+		// Contract: the free-text Reason must identify the offending row
+		// (kind + value name + index + colliding number) but must NOT inline
+		// any sheet/book name. Book/SheetName are attached as structured
+		// fields exactly once, by convertTableSheet's single-mode return
+		// path - re-wrapping at this layer would create two sources of
+		// truth and tempt callers into duplicating the sheet name inside
+		// Reason for "convenience".
+		msg := errs[2].Error()
+		if !strings.Contains(msg, "V3") {
+			t.Errorf("error free-text should reference the offending value name, got: %v", errs[2])
+		}
+		if !strings.Contains(msg, "union") {
+			t.Errorf("error free-text should identify the union kind, got: %v", errs[2])
+		}
+	})
+}
+
+// TestNewUnionField_NumberFallback is a thin end-to-end check that
+// parseUnionType's call site (newUnionField) wires resolveFieldNumber in
+// correctly. The exhaustive semantics are covered by TestResolveFieldNumber;
+// here we just confirm the union-specific wrapper returns the expected
+// resolved number for both legacy and collision cases.
+func TestNewUnionField_NumberFallback(t *testing.T) {
+	int32Ptr := func(v int32) *int32 { return &v }
+	gen := &Generator{}
+
+	collect := func(values []*internalpb.UnionDescriptor_Value) map[int32]struct{} {
+		used := make(map[int32]struct{}, len(values))
+		for _, v := range values {
+			if v.Number != nil {
+				used[*v.Number] = struct{}{}
+			}
+		}
+		return used
+	}
+
+	t.Run("legacy-all-empty", func(t *testing.T) {
+		values := []*internalpb.UnionDescriptor_Value{
+			{Name: "V1"}, {Name: "V2"}, {Name: "V3"},
+		}
+		used := collect(values)
+		want := []int32{1, 2, 3}
+		for i, v := range values {
+			field, err := newUnionField(i, v, gen, used)
+			if err != nil {
+				t.Fatalf("i=%d unexpected error: %v", i, err)
+			}
+			if field.Number != want[i] {
+				t.Errorf("i=%d Number = %d, want %d", i, field.Number, want[i])
+			}
+		}
+	})
+
+	t.Run("collision-reported", func(t *testing.T) {
+		values := []*internalpb.UnionDescriptor_Value{
+			{Name: "V1", Number: int32Ptr(3)},
+			{Name: "V2"}, // i=1, fallback 2 - ok
+			{Name: "V3"}, // i=2, fallback 3 - collides with V1
+		}
+		used := collect(values)
+		var errs []error
+		for i, v := range values {
+			_, err := newUnionField(i, v, gen, used)
+			errs = append(errs, err)
+		}
+		if errs[0] != nil || errs[1] != nil {
+			t.Fatalf("V1/V2 should resolve cleanly, got: %v / %v", errs[0], errs[1])
+		}
+		if errs[2] == nil {
+			t.Fatal("V3 should fail on i+1 fallback collision, got nil")
+		}
+		if !strings.Contains(errs[2].Error(), "union") {
+			t.Errorf("error should identify union kind, got: %v", errs[2])
+		}
+	})
 }


### PR DESCRIPTION
This PR fixes two related issues in `parseEnumType` / `parseUnionType` and the
single-mode error path that surfaces their errors. Both touch
`internal/protogen/sheet_mode.go` and the single-mode arm of
`internal/protogen/protogen.go`, so they are bundled into one change.

---

## Part 1 — Detect Number-column collisions in enum / union value sheets

### Problem

Enum and union descriptor sheets have an **optional** `Number` column.
The legacy rule was simple:

- if a row sets `Number` explicitly → use it;
- otherwise → fall back to `i + 1` (the 0-based row index plus one).

`unique: true` on the descriptor's `Number` field enforces that
**explicitly-set** values don't collide with each other. But when some
rows set `Number` and others leave it blank, nothing prevents the
`i + 1` fallback of a blank row from colliding with another row's
explicit value. The result was silently-duplicated proto field numbers,
which in turn produced duplicate generated enum values / union arms —
and the failure only surfaced much later, far from the offending sheet.

Concretely, a sheet like

| Name | Number |
|------|--------|
| V1   | 3      |
| V2   |        | ← i=1, fallback 2, OK |
| V3   |        | ← i=2, fallback 3, **collides with V1** |

would compile cleanly and emit two values with proto number `3`.

### Fix

Introduce `resolveFieldNumber` as the shared resolution helper for both
`parseEnumType` and `parseUnionType`:

- Build a `usedNumbers` set from all rows that set `Number` explicitly,
  in a pre-pass.
- Per row, if `Number` is set, return it as-is (uniqueness across
  explicit values is still enforced by the existing `unique` prop on
  the descriptor field).
- Otherwise return `i + 1`, but check `usedNumbers` first; on collision
  return a structured error that names the offending row and tells the
  author exactly what to do:

  ```
  <kind> value "<name>" (row index <i>) has empty Number column,
  but the fallback value <N> is already taken by another row's
  explicit Number. Either fill in the Number column for this row,
  or leave Number blank for all rows
  ```

When **no** row sets `Number`, `usedNumbers` is empty and the collision
check is a no-op, so the byte-for-byte behaviour of the legacy
auto-numbered `1..N` case is preserved.

### Tests

`internal/protogen/sheet_mode_test.go` (new):

- `TestResolveFieldNumber`
  - `all-blank-uses-fallback` — pure auto-numbering parity.
  - `all-explicit-uses-explicit-values`.
  - `mixed-no-collision-uses-fallback` — explicit `10, 30` + blanks at
    `i=1,3` → `10, 2, 30, 4`.
  - `mixed-collision-returns-error` — explicit `3` at `i=0` + blank at
    `i=2` (fallback `3`) → error on the third row; first two resolve
    cleanly. Asserts the `Reason` text references the offending value
    name and the `union` kind.
- `TestNewUnionField_NumberFallback/collision-reported` — same scenario
  driven through `newUnionField`, guards against future regressions
  that bypass `resolveFieldNumber`.

---

## Part 2 — Attach `BookName` / `SheetName` to single-mode sheet errors

### Problem

Errors raised inside single-mode sheets (`MODE_ENUM_TYPE` /
`MODE_STRUCT_TYPE` / `MODE_UNION_TYPE`) — including the new collision
error from Part 1 — render with empty structured fields in the `Desc`
summary:

```
BookName:  <no value>
SheetName: <no value>
Reason:    <kind> value "..." (row index N) has empty Number column, ...
```

The renderer template has dedicated `BookName` / `SheetName` slots, but
this code path never populated them.

### Root cause

`parseSpecialSheetMode`'s single-mode branches return their inner error
bare:

```go
case tableaupb.Mode_MODE_UNION_TYPE:
    if err := parseUnionType(...); err != nil {
        return nil, err   // no WrapKV
    }
```

`convertTableSheet` only does `sheetCollector.Collect(err)` — also
without attaching anything — and `bookCollector.Collect(sheetErr)` at
the outer layer doesn't wrap either. So the entire single-mode error
chain never carries `KeyBookName` / `KeySheetName` as structured fields.

Multi-mode (`MODE_*_TYPE_MULTI`) was already fine because each block
already does `WrapKV(KeyBookName, KeySheetName)` per-block at the
parse-error site. This PR brings single-mode to parity using one unified
attach point instead of duplicating the wrap across three branches.

### Fix

Make `convertTableSheet` the **single source of truth** for
`BookName` / `SheetName` on the single-mode error path:

```go
worksheets, err := gen.parseSpecialSheetMode(...)
if err != nil {
    return sheetCollector.Collect(xerrors.WrapKV(err,
        xerrors.KeyBookName,  debugBookName,
        xerrors.KeySheetName, debugSheetName))
}
```

One edit covers all three single-mode branches.

`xerrors.NewDesc` merges duplicate KV with **innermost-wins** semantics
(`internal/x/xerrors/desc.go`), so this outer layer doesn't fight with
anything wrapped deeper down.

### Cleanup of the downstream sources

With the unified attach point in place, downstream error sources no
longer need to plumb / wrap sheet name themselves:

- `resolveFieldNumber` does not accept `sheetName` and does not
  `WrapKV(KeySheetName, ...)`. Its `Reason` stays purely about the
  collision (kind + value name + row index + conflicting number).
- `newUnionField` does not accept `sheetName`. The previous
  `xerrors.Wrapf(err, "failed to parse union type %s of sheet: %s", ...)`
  loses its sheet-name tail and becomes `"failed to parse union type %s"`.
- `parseEnumType` / `parseUnionType` call sites updated accordingly.

This eliminates a second source of truth and removes the temptation for
future contributors to inline `sheet.Name` into free-text "for
convenience".

---

## After this change

Single-mode sheets now render fully-populated `BookName` / `SheetName`,
matching multi-mode behaviour, and the new collision error is reported
exactly where the author can act on it:

```
BookName:  <actual book>
SheetName: <actual sheet>
Reason:    <kind> value "..." (row index N) has empty Number column,
           but the fallback value M is already taken by another row's
           explicit Number. Either fill in the Number column for this
           row, or leave Number blank for all rows
```

## Verification

- `go test ./...` green, incl. `test/functest` e2e codegen.
- `go build ./...` clean.
- No new lint findings.
