### PR TITLE
fix(localizer): remove redundant PBFieldOpts concat in protogen error template

### DIFF
--- a/internal/localizer/i18n/config/message/en.yaml
+++ b/internal/localizer/i18n/config/message/en.yaml
@@ -11,7 +11,7 @@ protogen: |
   NameCellPos: {{.NameCellPos}}
   NameCell: {{.NameCell}}
   TypeCellPos: {{.TypeCellPos}}
-  TypeCell: {{.TypeCell}}{{ if .PBFieldOpts }}|{{.PBFieldOpts}}{{ end }}
+  TypeCell: {{.TypeCell}}
   Reason: {{.Reason}}
   {{- if .Help }}
   Help: {{.Help}}

--- a/internal/localizer/i18n/config/message/zh.yaml
+++ b/internal/localizer/i18n/config/message/zh.yaml
@@ -9,7 +9,7 @@ protogen: |
   命名单元格位置: {{.NameCellPos}}
   命名单元格数据: {{.NameCell}}
   类型单元格位置: {{.TypeCellPos}}
-  类型单元格数据: {{.TypeCell}}{{ if .PBFieldOpts }}|{{.PBFieldOpts}}{{ end }}
+  类型单元格数据: {{.TypeCell}}
   错误原因: {{.Reason}}
   {{ if .Help }}修复建议: {{.Help}}{{ end }}
 confgen: |


### PR DESCRIPTION
### Problem

When protogen reports a field error, the rendered message duplicates the prop segment:

```
Workbook: Item.xlsx (alias: Item)
Worksheet: #UnionItem
NameCellPos: D9
NameCell: ItemID
TypeCellPos: D9
TypeCell: int64|{"refer:ItemConf.ID"}|"refer:ItemConf.ID"
                                          ^^^^^^^^^^^^^^^^^^^^^ duplicated
Reason: failed to parse field prop: ...
```

The protogen template renders `TypeCell` as:

```
TypeCell: {{.TypeCell}}{{ if .PBFieldOpts }}|{{.PBFieldOpts}}{{ end }}
```

### Root cause

Audited every write site of `xerrors.KeyTypeCell` and `xerrors.KeyPBFieldOpts`:

| Write site | Content | Contains prop? |
|---|---|---|
| `protogen/util.go` `wrapDebugErr` → `header.getTypeCell` | raw type-row line | ✅ full `int64\|{...}` |
| `importer/book/node.go` `Node.DebugKV` → `n.Value` | raw YAML/JSON scalar | ✅ full `int64\|{...}` |
| ~25 sites writing `KeyPBFieldOpts` | `prop.Text` / `desc.Prop.Text` / `field.opts` | a substring of the above |

So in the protogen path, `TypeCell` *always* already carries the prop, and `PBFieldOpts` is just the same substring appended again.

`confgen` and `default` templates do not reference `PBFieldOpts` at all, so removing the concat has no impact there.

### Fix

Drop the `|{{.PBFieldOpts}}` suffix from `TypeCell` in both `zh.yaml` and `en.yaml`.

```diff
- 类型单元格数据: {{.TypeCell}}{{ if .PBFieldOpts }}|{{.PBFieldOpts}}{{ end }}
+ 类型单元格数据: {{.TypeCell}}

- TypeCell: {{.TypeCell}}{{ if .PBFieldOpts }}|{{.PBFieldOpts}}{{ end }}
+ TypeCell: {{.TypeCell}}
```

### Why `xerrors.KeyPBFieldOpts` is kept

- It still appears as its own line in the debug field block (`xerrors/desc.go fieldsString`), useful for locating prop parsing failures — note that `prop.Text` has its outer `{}` stripped, so it isn't strictly identical to `TypeCell`.
- Removing the constant would force changes across ~25 call sites with no functional benefit.

### After

```
TypeCell: int64|{"refer:ItemConf.ID"}
TypeCell: failed to parse field prop: ...
```

### Verification

- `go test ./internal/localizer/... ./internal/x/xerrors/...` ✅
- `go test ./internal/protogen/... ./internal/confgen/...` ✅

### Scope

Localized error template only; no production code changes.