### PR TITLE
fix(xerrors): do not silently drop foreign collected errors in Collector.Collect

### DIFF
--- a/internal/x/xerrors/collector.go
+++ b/internal/x/xerrors/collector.go
@@ -72,16 +72,22 @@ func (c *Collector) Collect(err error) error {
 		return nil
 	}
 
-	// Already-collected error (from a child's Join): remember the outer
-	// WrapKV layer on the child collector for re-wrapping in Join().
+	// Already-collected error (from a Join() somewhere): if the collected
+	// error originates from the same collector tree as c (shares the same
+	// root), it is or will be reachable from the root via tree auto-join, so
+	// we must not double-count it here. We only record the outer WrapKV
+	// layer on the originating collector for re-wrapping in its Join().
+	//
+	// Otherwise (foreign collected, e.g. from an unrelated parser-local
+	// fail-fast collector that is not part of c's tree), fall through and
+	// treat it as an ordinary error so it is still stored and counted on
+	// this collector; without this fallback the error would silently vanish.
 	var ce *collected
-	if errors.As(err, &ce) {
-		if ce.origin != nil {
-			if wm, ok := err.(*withMessage); ok {
-				ce.origin.mu.Lock()
-				ce.origin.outerWM = wm
-				ce.origin.mu.Unlock()
-			}
+	if errors.As(err, &ce) && ce.origin != nil && ce.origin.sameTreeAs(c) {
+		if wm, ok := err.(*withMessage); ok {
+			ce.origin.mu.Lock()
+			ce.origin.outerWM = wm
+			ce.origin.mu.Unlock()
 		}
 		if c.IsFull() {
 			return c.Join()
@@ -123,6 +129,24 @@ func (c *Collector) IsFull() bool {
 		}
 	}
 	return false
+}
+
+// root walks the parent chain and returns the topmost collector.
+func (c *Collector) root() *Collector {
+	cur := c
+	for cur.parent != nil {
+		cur = cur.parent
+	}
+	return cur
+}
+
+// sameTreeAs reports whether c and other share the same root collector,
+// i.e. they belong to the same collector tree built via NewChild.
+func (c *Collector) sameTreeAs(other *Collector) bool {
+	if c == nil || other == nil {
+		return false
+	}
+	return c.root() == other.root()
 }
 
 // HasErrors reports whether this collector's subtree has any errors.

--- a/internal/x/xerrors/collector_test.go
+++ b/internal/x/xerrors/collector_test.go
@@ -691,23 +691,28 @@ func TestCollected_JoinReturnsCollectedMarker(t *testing.T) {
 	assert.True(t, errors.As(joined, &ce), "Join() should return a collected-wrapped error")
 }
 
-// Collect skips collected-marked errors.
-func TestCollected_CollectSkipsCollectedError(t *testing.T) {
+// Collect treats a foreign collected error (from an unrelated collector
+// tree) as an ordinary error so it is not silently dropped.
+func TestCollected_CollectForeignCollectedIsNotDropped(t *testing.T) {
 	c := NewCollector(10)
 	_ = c.Collect(fmt.Errorf("err 1"))
 
 	joined := c.Join()
 	assert.Error(t, joined)
 
-	// Create a new collector and Collect the joined error.
-	// The collected marker should cause it to be skipped.
+	// Create a new, unrelated collector and Collect the joined error.
+	// Since joined.origin (= c) is not in c2's tree, c2 must keep it
+	// rather than silently drop it.
 	c2 := NewCollector(10)
 	_ = c2.Collect(joined)
-	assert.NoError(t, c2.Join(), "collected error should be skipped")
+	got := c2.Join()
+	assert.Error(t, got, "foreign collected error must not be silently dropped")
+	assert.Contains(t, got.Error(), "err 1")
 }
 
-// Collect skips collected marker even through WrapKV.
-func TestCollected_CollectSkipsWrappedCollectedError(t *testing.T) {
+// Collect treats a WrapKV'd foreign collected error as an ordinary error
+// so it is not silently dropped; the wrapping fields remain available.
+func TestCollected_CollectForeignWrappedCollectedIsNotDropped(t *testing.T) {
 	c := NewCollector(10)
 	_ = c.Collect(fmt.Errorf("err 1"))
 
@@ -715,8 +720,10 @@ func TestCollected_CollectSkipsWrappedCollectedError(t *testing.T) {
 	wrapped := WrapKV(joined, KeyBookName, "test.xlsx")
 
 	c2 := NewCollector(10)
-	_ = c2.Collect(wrapped) // collected marker detected, skip entirely
-	assert.NoError(t, c2.Join(), "WrapKV'd collected error should be skipped")
+	_ = c2.Collect(wrapped)
+	got := c2.Join()
+	assert.Error(t, got, "WrapKV'd foreign collected error must not be silently dropped")
+	assert.Contains(t, got.Error(), "err 1")
 }
 
 // collected marker is transparent: Error() delegates to inner.

--- a/internal/x/xerrors/collector_test.go
+++ b/internal/x/xerrors/collector_test.go
@@ -726,6 +726,58 @@ func TestCollected_CollectForeignWrappedCollectedIsNotDropped(t *testing.T) {
 	assert.Contains(t, got.Error(), "err 1")
 }
 
+// Collecting a WrapKV'd same-tree collected error records the outer WrapKV
+// layer on the originating collector so Join() can re-apply the fields.
+func TestCollected_CollectSameTreeWrappedCollectedRecordsOuterWM(t *testing.T) {
+	root := NewCollector(10)
+	child := root.NewChild(0)
+	_ = child.Collect(fmt.Errorf("err 1"))
+
+	joined := child.Join()
+	assert.Error(t, joined)
+	wrapped := WrapKV(joined, KeyBookName, "test.xlsx")
+
+	// root and child share a tree, so the collected marker is recognized
+	// and the outer WrapKV layer is recorded on child (origin) for Join().
+	_ = root.Collect(wrapped)
+
+	if assert.NotNil(t, child.outerWM, "outer WrapKV layer should be recorded on the originating collector") {
+		assert.Equal(t, "test.xlsx", child.outerWM.fields[KeyBookName])
+	}
+
+	// child.Join() re-applies the recorded fields, surfacing them in its Desc.
+	rejoined := child.Join()
+	assert.NotNil(t, rejoined)
+	assert.Equal(t, "test.xlsx", NewDesc(rejoined).fields[KeyBookName])
+}
+
+// Collecting a same-tree collected error when the receiver is already full
+// returns the joined error tree immediately (early termination).
+func TestCollected_CollectSameTreeCollectedWhenFullReturnsJoin(t *testing.T) {
+	root := NewCollector(1) // fail-fast: full after the first error
+	child := root.NewChild(0)
+	_ = child.Collect(fmt.Errorf("err 1"))
+	assert.True(t, root.IsFull(), "root should be full after child collects one error")
+
+	joined := child.Join()
+	assert.Error(t, joined)
+
+	// Same-tree collected marker is recognized; root is full, so Collect
+	// short-circuits and returns root.Join() instead of nil.
+	got := root.Collect(joined)
+	assert.Error(t, got, "full collector should return Join() for a same-tree collected error")
+}
+
+// sameTreeAs handles nil receivers/arguments defensively.
+func TestCollector_SameTreeAs_Nil(t *testing.T) {
+	c := NewCollector(10)
+	assert.False(t, c.sameTreeAs(nil), "nil other should not be same tree")
+
+	var nilCollector *Collector
+	assert.False(t, nilCollector.sameTreeAs(c), "nil receiver should not be same tree")
+	assert.False(t, nilCollector.sameTreeAs(nil), "nil receiver and nil other should not be same tree")
+}
+
 // collected marker is transparent: Error() delegates to inner.
 func TestCollected_ErrorDelegates(t *testing.T) {
 	c := NewCollector(10)


### PR DESCRIPTION
## Problem

`xerrors.Collector.Collect` short-circuited on **any** `*collected` error:

```go
var ce *collected
if errors.As(err, &ce) {
    // record outerWM, return; no append to errs, no counter bump
    return nil
}
```

This branch was designed for the case where the incoming error comes from one of `c`'s own descendant collectors — that error is already reachable from the root via tree auto-join, so re-counting it on `c` would produce duplicates.

However, the same branch also matched **foreign** `*collected` values: errors produced by an unrelated, parser-local fail-fast collector that is **not** a child of `c`. The canonical example in this repo:

- `confgen.NewExtendedSheetParser` creates its own `xerrors.NewCollector(1)` for in-sheet fail-fast diagnostics (`internal/confgen/parser.go:333`).
- When `protogen.parseEnumTypeSheet` (mode `MODE_ENUM_TYPE_MULTI`) calls into confgen and the sheet parser hits an error, confgen's local collector calls `Join()` and returns a `*collected{origin: parserLocalCol}` up the call chain.
- The outer `protogen.go:716` does `sheetCollector.Collect(xerrors.WrapKV(blockErr, KeyBookName, ..., KeySheetName, ...))`.
- `sheetCollector` is built via `bookCollector.NewChild(...)` and has **no parent relationship** with `parserLocalCol`, so the short-circuit was firing on a foreign origin.

Net effect:

- The error was neither appended to `sheetCollector.errs` nor counted.
- `outerWM` was written onto the foreign collector (which `sheetCollector.Join()` never visits).
- `sheetCollector.HasErrors()` stayed `false`, `Join()` returned `nil`.
- The "sub-field value not unique" diagnostic (and any other confgen-surfaced error reaching protogen via `parseEnumType` / `parseStructType`) was silently swallowed and the tool exited 0 with no output.

## Fix

Tighten the short-circuit so it only fires when the collected error's origin is part of `c`'s own collector tree (shares the same root reachable via the `parent` chain).

```go
if errors.As(err, &ce) && ce.origin != nil && ce.origin.sameTreeAs(c) {
    // same tree → reachable from root via auto-join; only record outerWM
    return nil
}
// otherwise fall through to the ordinary path: append + count
```

Two small helpers (`root`, `sameTreeAs`) are added to `Collector`. They are pure parent-chain walks, no locks needed.

### Semantics after the fix

`Collect(err)` where `err` is `*collected` with origin `oc`:

| Case | Behavior |
|---|---|
| `oc` is in the same collector tree as `c` (shares root) | Unchanged: record outer `WrapKV` fields on `oc` and return; do not double-count. |
| `oc` is foreign (different tree, e.g. parser-local fail-fast collector) | New: treat as an ordinary error — append to `c.errs`, bump every ancestor's counter. `HasErrors()` and `Join()` now surface it. |

## Tests

- Renamed two tests whose assertions encoded the buggy "silently drop foreign collected" behavior:
  - `TestCollected_CollectSkipsCollectedError` → `TestCollected_CollectForeignCollectedIsNotDropped`
  - `TestCollected_CollectSkipsWrappedCollectedError` → `TestCollected_CollectForeignWrappedCollectedIsNotDropped`

  Both now assert that the foreign (and `WrapKV`-wrapped foreign) collected error survives `Collect` and shows up in `Join()`.

- `TestCollected_CrossSubtreeCollection` keeps its original assertion (same-tree siblings between `outerChild` / `innerChild` under `docChild`): outer must **not** re-count an inner sibling's `*collected`. The new same-tree predicate covers this case unchanged.

- All other `internal/x/xerrors` tests pass without modification.

## Verification

```
$ go test -count=1 ./internal/x/xerrors/...
ok  	github.com/tableauio/tableau/internal/x/xerrors	0.016s

$ go test -count=1 ./...
ok  	github.com/tableauio/tableau/internal/confgen
ok  	github.com/tableauio/tableau/internal/protogen
ok  	github.com/tableauio/tableau/internal/x/xerrors
... (all packages green)
```

## Compatibility

- Pure semantic widening: previously-dropped errors now surface. No callers in this repo relied on the dropped behavior; the renamed tests were the only place that asserted it.
- Same-tree behavior is bit-for-bit unchanged, so existing protogen / confgen / load happy paths and intentional sibling-aggregation patterns are unaffected.
