### PR TITLE
fix(ci): trigger buf-ci on tag pushes to sync BSR labels

### DIFF
--- a/.github/workflows/buf-ci.yml
+++ b/.github/workflows/buf-ci.yml
@@ -1,7 +1,6 @@
 name: Buf CI
 on:
   push:
-    branches: ['**']
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   delete:


### PR DESCRIPTION
## Problem

Git tags (e.g. `v0.16.2`) pushed to this repo were never synced to the BSR (Buf Schema Registry) as labels.

## Root Cause

`buf-ci.yml`'s push trigger was filtered with `branches: ["**"]`:

```yaml
on:
  push:
    branches: ['**']
```

GitHub Actions' `branches` filter only matches refs under `refs/heads/*`, it never matches `refs/tags/*`. So pushing a tag (`git push origin v0.16.2`) never triggered `buf-ci.yml` at all, meaning `bufbuild/buf-action`'s `buf push` step never ran for that ref, and BSR never got a corresponding `v0.16.2` label.

This matches `bufbuild/buf-action`'s own recommended example workflow, which uses an unfiltered `push:` trigger so it fires on both branch and tag pushes.

## Fix

Remove the `branches` filter so the `push` trigger fires on both branch and tag pushes:

```yaml
on:
  push:
  pull_request:
    types: [opened, synchronize, reopened, labeled, unlabeled]
  delete:
```

## Notes

- I manually ran `buf push --git-metadata --exclude-unnamed` against the `v0.16.2` tag locally to backfill the missing BSR label; `buf.build/tableauio/tableau:v0.16.2` now exists on BSR.
- This PR only fixes the workflow trigger so future tags sync automatically.