### PR TITLE
feat(cmd): add --preserve-field-numbers CLI flag

### DIFF
--- a/cmd/tableauc/main.go
+++ b/cmd/tableauc/main.go
@@ -26,6 +26,8 @@ var (
 	indir        string
 	outdir       string
 
+	preserveFieldNumbers bool
+
 	confInputIgnoreUnknownWorkbook bool
 	confOutputSubdir               string
 	confOutputFormats              []string
@@ -48,6 +50,7 @@ func main() {
 	rootCmd.Flags().StringVarP(&protoPackage, "proto-package", "p", "protoconf", "Protobuf package name.")
 	rootCmd.Flags().StringVarP(&indir, "indir", "i", ".", "Input directory, default is current directory.")
 	rootCmd.Flags().StringVarP(&outdir, "outdir", "o", ".", "Output directory, default is current directory.")
+	rootCmd.Flags().BoolVarP(&preserveFieldNumbers, "preserve-field-numbers", "", false, `Preserve protobuf field numbers for backward/forward compatibility (assign new fields the max field number + 1), set it to override proto.output.preserveFieldNumbers.`)
 	rootCmd.Flags().StringVarP(&confOutputSubdir, "conf-output-subdir", "", "", "Conf output sub-directory, set it to override conf.output.subdir.")
 	rootCmd.Flags().StringSliceVarP(&confOutputFormats, "conf-output-formats", "", nil, "Available format: json, binpb, and txtpb, set it to override conf.output.formats.")
 	rootCmd.Flags().BoolVarP(&confInputIgnoreUnknownWorkbook, "conf-input-ignore-unknown-workbook", "", false, `Whether converter will not report an error and abort if a workbook
@@ -76,7 +79,7 @@ func run(cmd *cobra.Command, args []string) {
 	}
 }
 
-func runE(_ *cobra.Command, args []string) error {
+func runE(cmd *cobra.Command, args []string) error {
 	if showConfigSample {
 		return ShowConfigSample()
 	}
@@ -90,6 +93,11 @@ func runE(_ *cobra.Command, args []string) error {
 	}
 	if err := log.Init(config.Log); err != nil {
 		return fmt.Errorf("init log failed: %s", err)
+	}
+	if cmd.Flags().Changed("preserve-field-numbers") {
+		// override proto.output.preserveFieldNumbers in config file if the
+		// flag is explicitly set (either true or false).
+		config.Proto.Output.PreserveFieldNumbers = preserveFieldNumbers
 	}
 	if len(confOutputFormats) != 0 {
 		var formats []format.Format

--- a/cmd/tableauc/main.go
+++ b/cmd/tableauc/main.go
@@ -39,7 +39,17 @@ var (
 )
 
 func main() {
-	var rootCmd = &cobra.Command{
+	rootCmd := newRootCmd()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(-1)
+	}
+}
+
+// newRootCmd builds the root cobra command with all flags registered.
+// Extracted from main for testability.
+func newRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
 		Use:     "tableauc [FILE]...",
 		Version: genVersion(),
 		Short:   "tableauc is a modern configuration converter.",
@@ -65,10 +75,7 @@ is not recognized in proto files.`)
 	rootCmd.Flags().BoolVarP(&showConfigSample, "show-config-sample", "s", false, "Show config sample.")
 	rootCmd.Flags().StringVarP(&dryRun, "dry-run", "", "", "Preview the final result, available: patch.")
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(-1)
-	}
+	return rootCmd
 }
 
 func run(cmd *cobra.Command, args []string) {
@@ -94,26 +101,7 @@ func runE(cmd *cobra.Command, args []string) error {
 	if err := log.Init(config.Log); err != nil {
 		return fmt.Errorf("init log failed: %s", err)
 	}
-	if cmd.Flags().Changed("preserve-field-numbers") {
-		// override proto.output.preserveFieldNumbers in config file if the
-		// flag is explicitly set (either true or false).
-		config.Proto.Output.PreserveFieldNumbers = preserveFieldNumbers
-	}
-	if len(confOutputFormats) != 0 {
-		var formats []format.Format
-		for _, fmt := range confOutputFormats {
-			formats = append(formats, format.Format(fmt))
-		}
-		config.Conf.Output.Formats = formats
-	}
-	if confInputIgnoreUnknownWorkbook {
-		// use command argument if provided
-		config.Conf.Input.IgnoreUnknownWorkbook = true
-	}
-	if dryRun != "" {
-		// use command argument if provided
-		config.Conf.Output.DryRun = dryRun
-	}
+	applyFlags(cmd, config)
 	yamlOut, _ := yaml.Marshal(config)
 	log.Debugf("loaded config:\n%s", string(yamlOut))
 
@@ -134,6 +122,48 @@ func runE(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// applyFlags applies command-line flag overrides to the loaded config. Each
+// override takes effect only when its flag is explicitly provided on the
+// command line, so config-file values are preserved when a flag is omitted.
+//
+// --preserve-field-numbers is bidirectional: both --preserve-field-numbers
+// and --preserve-field-numbers=false override the config value (the latter
+// disables it even when set to true in the config file). The other flags
+// preserve their pre-existing, one-directional override semantics.
+//
+// NOTE: --conf-output-subdir is applied later in genConf to gain dynamic
+// output subdir ability, so it is intentionally not handled here.
+func applyFlags(cmd *cobra.Command, config *options.Options) {
+	if cmd.Flags().Changed("preserve-field-numbers") {
+		// override proto.output.preserveFieldNumbers in config file if the
+		// flag is explicitly set (either true or false).
+		v, _ := cmd.Flags().GetBool("preserve-field-numbers")
+		config.Proto.Output.PreserveFieldNumbers = v
+	}
+	if cmd.Flags().Changed("conf-output-formats") {
+		formats, _ := cmd.Flags().GetStringSlice("conf-output-formats")
+		if len(formats) != 0 {
+			var fs []format.Format
+			for _, f := range formats {
+				fs = append(fs, format.Format(f))
+			}
+			config.Conf.Output.Formats = fs
+		}
+	}
+	if cmd.Flags().Changed("conf-input-ignore-unknown-workbook") {
+		// use command argument if provided
+		if v, _ := cmd.Flags().GetBool("conf-input-ignore-unknown-workbook"); v {
+			config.Conf.Input.IgnoreUnknownWorkbook = true
+		}
+	}
+	if cmd.Flags().Changed("dry-run") {
+		// use command argument if provided
+		if v, _ := cmd.Flags().GetString("dry-run"); v != "" {
+			config.Conf.Output.DryRun = options.DryRun(v)
+		}
+	}
 }
 
 // genProto runs the proto generator to convert the specified workbooks into .proto files.

--- a/cmd/tableauc/main_test.go
+++ b/cmd/tableauc/main_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tableauio/tableau/format"
+	"github.com/tableauio/tableau/options"
+)
+
+// newCmd parses the given CLI args against a freshly built root command and
+// returns it, ready to be passed to applyFlags. It mirrors how tableauc is
+// actually invoked (real flag registration), so a mismatch between a flag's
+// registered name and the name looked up inside applyFlags would surface here.
+func newCmd(t *testing.T, args ...string) *cobra.Command {
+	t.Helper()
+	cmd := newRootCmd()
+	require.NoError(t, cmd.ParseFlags(args))
+	return cmd
+}
+
+// TestApplyFlags_PreserveFieldNumbers covers the --preserve-field-numbers
+// flag's bidirectional override of proto.output.preserveFieldNumbers.
+//
+// The key case is "config true + flag false -> false": a plain bool flag
+// cannot distinguish "not passed" (default false) from "explicitly passed
+// false", so this only works because applyFlags gates on
+// cmd.Flags().Changed(...) rather than the flag's truthiness.
+func TestApplyFlags_PreserveFieldNumbers(t *testing.T) {
+	cases := []struct {
+		name string
+		seed bool // config value before applying flags
+		args []string
+		want bool
+	}{
+		{"flag omitted: default false preserved", false, nil, false},
+		{"flag omitted: config true preserved", true, nil, true},
+		{"bare flag enables from false", false, []string{"--preserve-field-numbers"}, true},
+		{"bare flag keeps true", true, []string{"--preserve-field-numbers"}, true},
+		{"explicit true enables from false", false, []string{"--preserve-field-numbers=true"}, true},
+		{"explicit true keeps true", true, []string{"--preserve-field-numbers=true"}, true},
+		{"explicit false disables even when config true", true, []string{"--preserve-field-numbers=false"}, false},
+		{"explicit false keeps false", false, []string{"--preserve-field-numbers=false"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newCmd(t, tc.args...)
+			config := options.NewDefault()
+			config.Proto.Output.PreserveFieldNumbers = tc.seed
+			applyFlags(cmd, config)
+			assert.Equal(t, tc.want, config.Proto.Output.PreserveFieldNumbers)
+		})
+	}
+}
+
+// TestApplyFlags_ConfOutputFormats verifies the consolidation of the
+// --conf-output-formats override into applyFlags did not change behavior:
+// the flag overrides only when a non-empty list is provided.
+func TestApplyFlags_ConfOutputFormats(t *testing.T) {
+	t.Run("flag overrides formats", func(t *testing.T) {
+		cmd := newCmd(t, "--conf-output-formats=binpb,txtpb")
+		config := options.NewDefault()
+		applyFlags(cmd, config)
+		assert.Equal(t, []format.Format{format.Bin, format.Text}, config.Conf.Output.Formats)
+	})
+	t.Run("flag omitted preserves config formats", func(t *testing.T) {
+		cmd := newCmd(t)
+		config := options.NewDefault()
+		want := []format.Format{format.JSON}
+		applyFlags(cmd, config)
+		assert.Equal(t, want, config.Conf.Output.Formats)
+	})
+}
+
+// TestApplyFlags_ConfInputIgnoreUnknownWorkbook verifies the
+// --conf-input-ignore-unknown-workbook override still only enables (never
+// disables): its pre-existing one-directional semantics are preserved.
+func TestApplyFlags_ConfInputIgnoreUnknownWorkbook(t *testing.T) {
+	t.Run("flag enables", func(t *testing.T) {
+		cmd := newCmd(t, "--conf-input-ignore-unknown-workbook")
+		config := options.NewDefault()
+		applyFlags(cmd, config)
+		assert.True(t, config.Conf.Input.IgnoreUnknownWorkbook)
+	})
+	t.Run("flag omitted preserves config", func(t *testing.T) {
+		cmd := newCmd(t)
+		config := options.NewDefault()
+		config.Conf.Input.IgnoreUnknownWorkbook = true
+		applyFlags(cmd, config)
+		assert.True(t, config.Conf.Input.IgnoreUnknownWorkbook)
+	})
+	t.Run("flag=false does not disable (existing one-directional behavior)", func(t *testing.T) {
+		cmd := newCmd(t, "--conf-input-ignore-unknown-workbook=false")
+		config := options.NewDefault()
+		config.Conf.Input.IgnoreUnknownWorkbook = true
+		applyFlags(cmd, config)
+		assert.True(t, config.Conf.Input.IgnoreUnknownWorkbook)
+	})
+}
+
+// TestApplyFlags_DryRun verifies the --dry-run override still only applies
+// when a non-empty value is provided.
+func TestApplyFlags_DryRun(t *testing.T) {
+	t.Run("flag overrides dry-run", func(t *testing.T) {
+		cmd := newCmd(t, "--dry-run=patch")
+		config := options.NewDefault()
+		applyFlags(cmd, config)
+		assert.Equal(t, options.DryRunPatch, config.Conf.Output.DryRun)
+	})
+	t.Run("flag omitted preserves config", func(t *testing.T) {
+		cmd := newCmd(t)
+		config := options.NewDefault()
+		applyFlags(cmd, config)
+		assert.Equal(t, options.DryRun(""), config.Conf.Output.DryRun)
+	})
+}


### PR DESCRIPTION
## What

Adds a new `--preserve-field-numbers` CLI flag to `tableauc` that overrides the `proto.output.preserveFieldNumbers` setting in `config.yaml`.

## Why

`PreserveFieldNumbers` (proto output option) controls whether protobuf field numbers are preserved for backward/forward compatibility — when a new field name appears, it's assigned the max existing field number + 1 rather than a fresh sequential number. Currently this is only configurable via `config.yaml`. This PR makes it settable from the command line, consistent with the other override flags (`--conf-output-formats`, `--conf-output-subdir`, `--conf-input-ignore-unknown-workbook`, `--dry-run`).

## Design note: bidirectional override

A plain bool flag can't distinguish **"flag not passed"** (default `false`) from **"user passed `--preserve-field-numbers=false`"** — both leave the variable `false`. So a naive truthy check (`if preserveFieldNumbers { ... = true }`) could only ever *enable* the option, never *disable* it, even if `config.yaml` sets it to `true`.

To support disabling too, this flag uses `cmd.Flags().Changed("preserve-field-numbers")`, which is `true` only when the flag is explicitly provided on the command line. Behavior:

| Invocation | Result |
| --- | --- |
| *(flag omitted)* | value from `config.yaml` wins (default `false`) |
| `--preserve-field-numbers` | `true` |
| `--preserve-field-numbers=false` | `false` (disables even if config says `true`) |

> Note: the sibling flag `--conf-input-ignore-unknown-workbook` has the same one-directional limitation, but I left it untouched to keep this PR focused and avoid changing existing behavior. Happy to apply the same `Changed()` treatment in a follow-up if desired.

## Verification

- `gofmt -l` clean, `go build ./...` passes, `go vet ./...` passes.
- `tableauc --help` lists the new flag with the correct name (so the `Changed()` string matches the registration — a mismatch would silently never fire the override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)