### PR TITLE
perf: lazily compute proto registry; ci: fix Go setup and add generate check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: v2.2.1
+          version: latest
 
       - name: Install Buf
         uses: bufbuild/buf-action@v1
@@ -37,6 +37,17 @@ jobs:
           buf generate
           if git diff --name-only | grep -q "\.go$"; then
             echo "Error: Generated Go files are not committed"
+            git diff
+            exit 1
+          fi
+
+      - name: Go Generate and Check
+        run: |
+          go generate ./...
+          if ! git diff --quiet; then
+            echo "Error: 'go generate ./...' produced uncommitted changes."
+            echo "Run 'go generate ./...' locally and commit the result."
+            git status --short
             git diff
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.x"
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - name: Download dependencies
         run: go mod download

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,14 +22,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-
-      - name: Checkout Code
-        uses: actions/checkout@v7
 
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,6 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x]
         os: [ubuntu-latest, windows-latest]
         targetplatform: [x86, x64]
 
@@ -26,7 +25,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/internal/protogen/exporter.go
+++ b/internal/protogen/exporter.go
@@ -391,7 +391,7 @@ func (x *sheetExporter) findMDFromGeneratedProtos(name string) protoreflect.Mess
 		return nil
 	}
 	fullName := protoreflect.FullName(x.be.ProtoPackage).Append(protoreflect.Name(name))
-	descriptor, err := x.be.gen.GetProtoRegistryFilesWithGenerated().FindDescriptorByName(fullName)
+	descriptor, err := x.be.gen.getProtoRegistryFilesWithGenerated().FindDescriptorByName(fullName)
 	if err != nil {
 		return nil
 	}

--- a/internal/protogen/exporter.go
+++ b/internal/protogen/exporter.go
@@ -391,7 +391,7 @@ func (x *sheetExporter) findMDFromGeneratedProtos(name string) protoreflect.Mess
 		return nil
 	}
 	fullName := protoreflect.FullName(x.be.ProtoPackage).Append(protoreflect.Name(name))
-	descriptor, err := x.be.gen.ProtoRegistryFilesWithGenerated.FindDescriptorByName(fullName)
+	descriptor, err := x.be.gen.GetProtoRegistryFilesWithGenerated().FindDescriptorByName(fullName)
 	if err != nil {
 		return nil
 	}

--- a/internal/protogen/exporter_test.go
+++ b/internal/protogen/exporter_test.go
@@ -628,7 +628,7 @@ func Test_sheetExporter_exportStruct(t *testing.T) {
 						OutputOpt: &options.ProtoOutputOption{
 							PreserveFieldNumbers: true,
 						},
-						ProtoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
+						protoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
 					},
 				},
 				typeInfos:      &xproto.TypeInfos{},
@@ -665,7 +665,7 @@ func Test_sheetExporter_exportStruct(t *testing.T) {
 						OutputOpt: &options.ProtoOutputOption{
 							PreserveFieldNumbers: true,
 						},
-						ProtoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
+						protoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
 					},
 				},
 				typeInfos:      &xproto.TypeInfos{},
@@ -793,7 +793,7 @@ func Test_sheetExporter_exportUnion(t *testing.T) {
 						OutputOpt: &options.ProtoOutputOption{
 							PreserveFieldNumbers: true,
 						},
-						ProtoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
+						protoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
 					},
 				},
 				typeInfos:      &xproto.TypeInfos{},
@@ -1015,7 +1015,7 @@ func Test_sheetExporter_exportMessager(t *testing.T) {
 						OutputOpt: &options.ProtoOutputOption{
 							PreserveFieldNumbers: true,
 						},
-						ProtoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
+						protoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
 					},
 				},
 				typeInfos:      &xproto.TypeInfos{},
@@ -1098,7 +1098,7 @@ func Test_sheetExporter_exportMessager(t *testing.T) {
 						OutputOpt: &options.ProtoOutputOption{
 							PreserveFieldNumbers: true,
 						},
-						ProtoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
+						protoRegistryFilesWithGenerated: protoregistry.GlobalFiles,
 					},
 				},
 				typeInfos:      &xproto.TypeInfos{},

--- a/internal/protogen/protogen.go
+++ b/internal/protogen/protogen.go
@@ -47,12 +47,16 @@ type Generator struct {
 	InputOpt     *options.ProtoInputOption
 	OutputOpt    *options.ProtoOutputOption
 
-	ProtoRegistryFiles, ProtoRegistryFilesWithGenerated *protoregistry.Files
-	ProtoRegistryTypes                                  *dynamicpb.Types
+	ProtoRegistryFiles *protoregistry.Files
+	ProtoRegistryTypes *dynamicpb.Types
 
 	// internal
 	typeInfos *xproto.TypeInfos  // predefined type infos
 	collector *xerrors.Collector // concurrent error collector shared across the generator.
+
+	// used in advanced mode or when preserveFieldNumbers is set to true
+	registryWithGeneratedOnce       sync.Once
+	protoRegistryFilesWithGenerated *protoregistry.Files
 
 	cacheMu         sync.RWMutex                 // guard fields below
 	cachedImporters map[string]importer.Importer // absolute file path -> importer
@@ -86,13 +90,30 @@ func NewGeneratorWithOptions(protoPackage, indir, outdir string, opts *options.O
 		panic(err)
 	}
 	gen.ProtoRegistryFiles = registryFiles
-	registryFiles, err = gen.parseProtoRegistryFiles(true)
-	if err != nil {
-		panic(err)
-	}
-	gen.ProtoRegistryFilesWithGenerated = registryFiles
 	gen.ProtoRegistryTypes = dynamicpb.NewTypes(registryFiles)
+	// NOTE: ProtoRegistryFilesWithGenerated is lazily computed by
+	// GetProtoRegistryFilesWithGenerated() on first use.
 	return gen
+}
+
+// GetProtoRegistryFilesWithGenerated returns a registry that includes both
+// the user-specified imported protos and the previously generated protos
+// under outdir. It parses on first call (under sync.Once) and caches the
+// result in [Generator.ProtoRegistryFilesWithGenerated]; subsequent calls
+// return the cached value. If the field is already set (e.g. by tests),
+// it is returned as-is without invoking the parser.
+func (gen *Generator) GetProtoRegistryFilesWithGenerated() *protoregistry.Files {
+	if gen.protoRegistryFilesWithGenerated != nil {
+		return gen.protoRegistryFilesWithGenerated
+	}
+	gen.registryWithGeneratedOnce.Do(func() {
+		files, err := gen.parseProtoRegistryFiles(true)
+		if err != nil {
+			panic(err)
+		}
+		gen.protoRegistryFilesWithGenerated = files
+	})
+	return gen.protoRegistryFilesWithGenerated
 }
 
 func (gen *Generator) parseProtoRegistryFiles(useGeneratedProtos bool) (*protoregistry.Files, error) {
@@ -117,7 +138,12 @@ func (gen *Generator) preprocess(useGeneratedProtos, delExisted bool) error {
 	// parse custom imported proto files
 	protoRegistryFiles := gen.ProtoRegistryFiles
 	if useGeneratedProtos {
-		protoRegistryFiles = gen.ProtoRegistryFilesWithGenerated
+		protoRegistryFiles = gen.GetProtoRegistryFilesWithGenerated()
+	}
+	if gen.OutputOpt.PreserveFieldNumbers {
+		// if preserveFieldNumbers enabled, parse generated protos before they
+		// are deleted
+		_ = gen.GetProtoRegistryFilesWithGenerated()
 	}
 	gen.typeInfos = xproto.GetAllTypeInfo(protoRegistryFiles, gen.ProtoPackage)
 	return prepareOutdir(outdir, gen.InputOpt.ProtoFiles, delExisted)

--- a/internal/protogen/protogen.go
+++ b/internal/protogen/protogen.go
@@ -91,18 +91,15 @@ func NewGeneratorWithOptions(protoPackage, indir, outdir string, opts *options.O
 	}
 	gen.ProtoRegistryFiles = registryFiles
 	gen.ProtoRegistryTypes = dynamicpb.NewTypes(registryFiles)
-	// NOTE: ProtoRegistryFilesWithGenerated is lazily computed by
-	// GetProtoRegistryFilesWithGenerated() on first use.
+	// NOTE: protoRegistryFilesWithGenerated is lazily computed by
+	// getProtoRegistryFilesWithGenerated() on first use.
 	return gen
 }
 
-// GetProtoRegistryFilesWithGenerated returns a registry that includes both
-// the user-specified imported protos and the previously generated protos
-// under outdir. It parses on first call (under sync.Once) and caches the
-// result in [Generator.ProtoRegistryFilesWithGenerated]; subsequent calls
-// return the cached value. If the field is already set (e.g. by tests),
-// it is returned as-is without invoking the parser.
-func (gen *Generator) GetProtoRegistryFilesWithGenerated() *protoregistry.Files {
+// getProtoRegistryFilesWithGenerated returns a registry including both the
+// imported and previously generated protos, computing and caching it on
+// first use.
+func (gen *Generator) getProtoRegistryFilesWithGenerated() *protoregistry.Files {
 	if gen.protoRegistryFilesWithGenerated != nil {
 		return gen.protoRegistryFilesWithGenerated
 	}
@@ -137,13 +134,10 @@ func (gen *Generator) preprocess(useGeneratedProtos, delExisted bool) error {
 	outdir := filepath.Join(gen.OutputDir, gen.OutputOpt.Subdir)
 	// parse custom imported proto files
 	protoRegistryFiles := gen.ProtoRegistryFiles
-	if useGeneratedProtos {
-		protoRegistryFiles = gen.GetProtoRegistryFilesWithGenerated()
-	}
-	if gen.OutputOpt.PreserveFieldNumbers {
-		// if preserveFieldNumbers enabled, parse generated protos before they
-		// are deleted
-		_ = gen.GetProtoRegistryFilesWithGenerated()
+	// preserveFieldNumbers also needs generated protos parsed before they
+	// are deleted below.
+	if useGeneratedProtos || gen.OutputOpt.PreserveFieldNumbers {
+		protoRegistryFiles = gen.getProtoRegistryFilesWithGenerated()
 	}
 	gen.typeInfos = xproto.GetAllTypeInfo(protoRegistryFiles, gen.ProtoPackage)
 	return prepareOutdir(outdir, gen.InputOpt.ProtoFiles, delExisted)


### PR DESCRIPTION
## Summary

- **CI: use `go-version-file: go.mod` for Go setup** — removes the hardcoded/matrix Go version in `testing.yml` and `release.yml`, so CI always builds with the exact Go version declared in `go.mod` instead of a value that can silently drift out of sync.
- **perf: lazily compute proto registry with generated files** — `ProtoRegistryFilesWithGenerated` is only needed by a few call paths (`PreserveFieldNumbers`, `preprocess(useGeneratedProtos=true, ...)`, the exporter's advanced mode). Previously it was eagerly parsed/compiled in every `NewGeneratorWithOptions` call regardless of whether it was used. This change turns it into a `sync.Once`-guarded lazy getter, avoiding the extra glob+compile IO/CPU cost on the common path while still computing it once and caching the result when actually needed.
- **CI: bump `golangci-lint-action` to `latest` and add a `go generate` drift check** — ensures generated code (e.g. `embed.go` outputs) is always committed and up to date, catching stale generated files at PR time instead of at review time.
- **CI: fix step ordering in `testing.yml`** — `Install Go` (which reads `go-version-file: go.mod`) was running before `Checkout Code`, so the repo wasn't checked out yet and `go.mod` couldn't be found. Reordered so checkout happens first.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `go generate ./...` is idempotent (no diff after running).
