### PR TITLE
feat(confgen): add E2029 error code for missing digit-suffix cells in horizontal list/map fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Tableau is a Go-based configuration converter that transforms Excel/CSV/XML/YAML files into protobuf-defined configuration files (JSON, Text, Bin). It uses Protocol Buffers (proto3) to define the structure of input data, extended with custom tableau options (field numbers 50000-99999 on `google.protobuf.*Options`).
+Tableau is a Go-based configuration converter that transforms Excel/CSV/XML/YAML files into protobuf-defined configuration files (JSON, Text, Bin). It uses Protocol Buffers (proto3), extended with custom tableau options on `google.protobuf.*Options` (field numbers 50000-99999).
 
 ## Common Commands
 
@@ -35,7 +35,7 @@ go tool pprof -http :8888 cpu.prof
 ```bash
 go vet ./...
 
-# Full lint (CI uses golangci-lint v2.2.1)
+# Full lint (CI runs golangci-lint)
 golangci-lint run
 
 # Buf proto linting & build
@@ -144,7 +144,7 @@ Tableau extends protobuf descriptors at field numbers 50000:
 
 ### Concurrency Model
 
-- `xerrors.Collector`: Thread-safe error accumulator with configurable max capacity. Forms parent-child hierarchies. Uses `golang.org/x/sync/errgroup` for goroutine management.
+- `xerrors.Collector`: Thread-safe error accumulator with configurable max capacity, forming parent-child hierarchies.
 - `Collector.NewGroup()`: Creates an errgroup with the collector's context; goroutines call `g.Go()`.
 - `Collector.NewChild()`: Creates a child collector with its own capacity, registered under the parent.
 - The collector stops accepting new errors once full (`IsFull()` returns true), propagating early termination up the tree.
@@ -152,8 +152,8 @@ Tableau extends protobuf descriptors at field numbers 50000:
 ### Error Handling
 
 - Structured errors with key-value fields (`xerrors.NewKV`, `xerrors.WrapKV`).
-- Each error chain has exactly one stack trace (captured at creation via `callers()`).
-- Error codes (E0001-E3003) are generated from i18n config via `internal/tools/cmd/ecode`. Source: `internal/x/xerrors/ecode_generated.go`.
+- Each error chain has exactly one stack trace.
+- Error codes (E0001-E3003) are generated from i18n config via `internal/tools/cmd/ecode` into `internal/x/xerrors/ecode_generated.go`.
 - Errors carry structured fields: `module`, `bookName`, `sheetName`, `pbMessage`, `position` (Excel cell coordinates).
 - At debug log level, errors include full stack traces (`%+v`); at higher levels, concise format (`%v`).
 
@@ -167,7 +167,6 @@ Tableau extends protobuf descriptors at field numbers 50000:
 
 - Proto definitions live in `proto/tableau/protobuf/` and are published to the Buf Schema Registry (BSR) as `buf.build/tableauio/tableau`.
 - `buf.yaml` defines two modules: a named one (published, excludes `internal/` and `unittest/`) and an unnamed one (for internal protos used in testing).
-- Generated Go code goes to `proto/tableaupb/` via `buf generate`.
 - CI checks that generated `.pb.go` files are committed and up-to-date.
 - Dependency: `buf.build/bufbuild/protovalidate` for field validation.
 

--- a/internal/confgen/table_parser.go
+++ b/internal/confgen/table_parser.go
@@ -211,7 +211,7 @@ func (p *tableParser) parseHorizontalMapField(field *Field, msg protoreflect.Mes
 			// map field not found and is optional, just return false, nil.
 			return false, nil
 		}
-		return false, xerrors.Newf("no cell found with digit suffix for horizontal map field")
+		return false, xerrors.WrapKV(xerrors.E2029(field.opts.Name, "map"), r.CellDebugKV(newPrefix)...)
 	}
 	fixedSize := fieldprop.GetSize(field.opts.Prop, detectedSize)
 	size := detectedSize
@@ -488,7 +488,7 @@ func (p *tableParser) parseHorizontalListField(field *Field, msg protoreflect.Me
 			// list field not found and is optional, just return false, nil.
 			return false, nil
 		}
-		return false, xerrors.Newf("no cell found with digit suffix for horizontal list field")
+		return false, xerrors.WrapKV(xerrors.E2029(field.opts.Name, "list"), r.CellDebugKV(newPrefix)...)
 	}
 	fixedSize := fieldprop.GetSize(field.opts.Prop, detectedSize)
 	size := detectedSize

--- a/internal/confgen/table_parser_test.go
+++ b/internal/confgen/table_parser_test.go
@@ -474,7 +474,7 @@ func TestTableParser_parseHorizontalMapWithNoDigitSuffix(t *testing.T) {
 		})
 	err := parser.Parse(&unittestpb.RewardConf{}, sheet)
 	require.Error(t, err)
-	// Error code: E2029 (no cell found with digit suffix for horizontal map field).
+	// Error code: E2029 (no cell with digit suffix for horizontal map field).
 	require.ErrorIs(t, err, xerrors.ErrE2029)
 
 	desc := xerrors.NewDesc(err)
@@ -491,7 +491,7 @@ func TestTableParser_parseHorizontalMapWithNoDigitSuffix(t *testing.T) {
 	rendered := desc.String()
 	require.Contains(t, rendered, "error[E2029]:")
 	require.Contains(t, rendered, "DataCellPos: [B...C]2")
-	require.Contains(t, rendered, `no cell found with digit suffix for horizontal map field "Item"`)
+	require.Contains(t, rendered, `horizontal map field "Item" has no cell with a digit suffix`)
 }
 
 func TestTableParser_parseHorizontalListWithNoDigitSuffix(t *testing.T) {
@@ -520,7 +520,7 @@ func TestTableParser_parseHorizontalListWithNoDigitSuffix(t *testing.T) {
 		})
 	err := parser.Parse(&unittestpb.HorizontalListFieldConf{}, sheet)
 	require.Error(t, err)
-	// Error code: E2029 (no cell found with digit suffix for horizontal list field).
+	// Error code: E2029 (no cell with digit suffix for horizontal list field).
 	require.ErrorIs(t, err, xerrors.ErrE2029)
 
 	desc := xerrors.NewDesc(err)
@@ -537,7 +537,7 @@ func TestTableParser_parseHorizontalListWithNoDigitSuffix(t *testing.T) {
 	rendered := desc.String()
 	require.Contains(t, rendered, "error[E2029]:")
 	require.Contains(t, rendered, "DataCellPos: [B...C]2")
-	require.Contains(t, rendered, `no cell found with digit suffix for horizontal list field "Item"`)
+	require.Contains(t, rendered, `horizontal list field "Item" has no cell with a digit suffix`)
 }
 
 func TestTableParser_parseWithSheetAndBookSep(t *testing.T) {

--- a/internal/confgen/table_parser_test.go
+++ b/internal/confgen/table_parser_test.go
@@ -462,6 +462,84 @@ func TestTableParser_parseHorizontalMapWithEmptyKey(t *testing.T) {
 	}
 }
 
+func TestTableParser_parseHorizontalMapWithNoDigitSuffix(t *testing.T) {
+	parser := newTableParserForTest()
+	sheet := book.NewTableSheet(
+		"RewardConf",
+		[][]string{
+			// "ItemID"/"ItemNum" share the "Item" prefix but lack the digit
+			// suffix that a horizontal map field requires.
+			{"RewardID", "ItemID", "ItemNum"},
+			{"1", "100", "200"},
+		})
+	err := parser.Parse(&unittestpb.RewardConf{}, sheet)
+	require.Error(t, err)
+	// Error code: E2029 (no cell found with digit suffix for horizontal map field).
+	require.ErrorIs(t, err, xerrors.ErrE2029)
+
+	desc := xerrors.NewDesc(err)
+	require.Equal(t, xerrors.ModuleConf, desc.GetValue(xerrors.KeyModule))
+	// Semantic details from the ecode.
+	require.Equal(t, "Item", desc.GetValue("FieldName"))
+	require.Equal(t, "map", desc.GetValue("FieldType"))
+	// Excel position details: the matched prefix range and data row.
+	require.Equal(t, "Item", desc.GetValue(xerrors.KeyColumnName))
+	require.Equal(t, "[B...C]2", desc.GetValue(xerrors.KeyDataCellPos))
+	require.Equal(t, "[100...200]", desc.GetValue(xerrors.KeyDataCell))
+
+	// Rendered summary carries the code, position, and reason.
+	rendered := desc.String()
+	require.Contains(t, rendered, "error[E2029]:")
+	require.Contains(t, rendered, "DataCellPos: [B...C]2")
+	require.Contains(t, rendered, `no cell found with digit suffix for horizontal map field "Item"`)
+}
+
+func TestTableParser_parseHorizontalListWithNoDigitSuffix(t *testing.T) {
+	// Realistic shape: a vertical map keyed by ID, with each value containing
+	// a horizontal list of predefined unittest.Item elements (columns like
+	// "Item1ID", "Item1Num", "Item2ID", "Item2Num"). Verify the proto parses
+	// valid data before exercising the error path.
+	validSheet := book.NewTableSheet(
+		"HorizontalListFieldConf",
+		[][]string{
+			{"ID", "Item1ID", "Item1Num", "Item2ID", "Item2Num"},
+			{"1", "100", "10", "200", "20"},
+		})
+	if err := newTableParserForTest().Parse(&unittestpb.HorizontalListFieldConf{}, validSheet); err != nil {
+		t.Fatalf("valid sheet should parse without error, got: %v", err)
+	}
+
+	// Error case: "ItemID"/"ItemNum" share the "Item" prefix but lack the
+	// digit suffix that a horizontal list field requires.
+	parser := newTableParserForTest()
+	sheet := book.NewTableSheet(
+		"HorizontalListFieldConf",
+		[][]string{
+			{"ID", "ItemID", "ItemNum"},
+			{"1", "100", "200"},
+		})
+	err := parser.Parse(&unittestpb.HorizontalListFieldConf{}, sheet)
+	require.Error(t, err)
+	// Error code: E2029 (no cell found with digit suffix for horizontal list field).
+	require.ErrorIs(t, err, xerrors.ErrE2029)
+
+	desc := xerrors.NewDesc(err)
+	require.Equal(t, xerrors.ModuleConf, desc.GetValue(xerrors.KeyModule))
+	// Semantic details from the ecode.
+	require.Equal(t, "Item", desc.GetValue("FieldName"))
+	require.Equal(t, "list", desc.GetValue("FieldType"))
+	// Excel position details: the matched prefix range and data row.
+	require.Equal(t, "Item", desc.GetValue(xerrors.KeyColumnName))
+	require.Equal(t, "[B...C]2", desc.GetValue(xerrors.KeyDataCellPos))
+	require.Equal(t, "[100...200]", desc.GetValue(xerrors.KeyDataCell))
+
+	// Rendered summary carries the code, position, and reason.
+	rendered := desc.String()
+	require.Contains(t, rendered, "error[E2029]:")
+	require.Contains(t, rendered, "DataCellPos: [B...C]2")
+	require.Contains(t, rendered, `no cell found with digit suffix for horizontal list field "Item"`)
+}
+
 func TestTableParser_parseWithSheetAndBookSep(t *testing.T) {
 	parserWithBookSep := NewExtendedSheetParser(context.Background(), "protoconf", "Asia/Shanghai",
 		&tableaupb.WorkbookOptions{

--- a/internal/localizer/i18n/config/ecode/en.yaml
+++ b/internal/localizer/i18n/config/ecode/en.yaml
@@ -203,6 +203,13 @@ E2028:
   desc: duplicate elements in incell keyed-list
   text: keyed-list element {{ quote .Elem }} already exists
   help: fix duplicate elements and ensure keyed-list elements are unique
+E2029:
+  desc: no cell found with digit suffix for horizontal list/map field
+  text: 'no cell found with digit suffix for horizontal {{.FieldType}} field "{{.FieldName}}"'
+  help: 'add columns with digit suffix (e.g., "{{.FieldName}}1", "{{.FieldName}}2") to match the horizontal layout, or set prop "optional:true" if the field can be absent'
+  fields:
+    - FieldName: string
+    - FieldType: string
 # [3000, 3999]: importer error
 E3000:
   desc: no workbook file found about sheet specifier

--- a/internal/localizer/i18n/config/ecode/en.yaml
+++ b/internal/localizer/i18n/config/ecode/en.yaml
@@ -204,9 +204,9 @@ E2028:
   text: keyed-list element {{ quote .Elem }} already exists
   help: fix duplicate elements and ensure keyed-list elements are unique
 E2029:
-  desc: no cell found with digit suffix for horizontal list/map field
-  text: 'no cell found with digit suffix for horizontal {{.FieldType}} field "{{.FieldName}}"'
-  help: 'add columns with digit suffix (e.g., "{{.FieldName}}1", "{{.FieldName}}2") to match the horizontal layout, or set prop "optional:true" if the field can be absent'
+  desc: no cell with digit suffix for horizontal list/map field
+  text: 'horizontal {{.FieldType}} field "{{.FieldName}}" has no cell with a digit suffix'
+  help: 'add columns "{{.FieldName}}1", "{{.FieldName}}2", ...; or set prop "optional:true" if the field may be absent'
   fields:
     - FieldName: string
     - FieldType: string

--- a/internal/localizer/i18n/config/ecode/zh.yaml
+++ b/internal/localizer/i18n/config/ecode/zh.yaml
@@ -131,6 +131,10 @@ E2028:
   desc: duplicate elements in incell keyed-list
   text: "keyed-list元素 {{ quote .Elem }} 已存在"
   help: 确保keyed-list的元素唯一, 不能配置相同元素
+E2029:
+  desc: no cell found with digit suffix for horizontal list/map field
+  text: '横向 {{.FieldType}} 字段 "{{.FieldName}}" 未找到带数字后缀的单元格'
+  help: '请按横向布局添加带数字后缀的列（如 "{{.FieldName}}1"、"{{.FieldName}}2"），或设置字段属性 "optional:true" 表示该字段可缺省'
 # [3000, 3999]: importer error
 E3000:
   desc: no workbook file found about sheet specifier

--- a/internal/localizer/i18n/config/ecode/zh.yaml
+++ b/internal/localizer/i18n/config/ecode/zh.yaml
@@ -132,9 +132,9 @@ E2028:
   text: "keyed-list元素 {{ quote .Elem }} 已存在"
   help: 确保keyed-list的元素唯一, 不能配置相同元素
 E2029:
-  desc: no cell found with digit suffix for horizontal list/map field
+  desc: no cell with digit suffix for horizontal list/map field
   text: '横向 {{.FieldType}} 字段 "{{.FieldName}}" 未找到带数字后缀的单元格'
-  help: '请按横向布局添加带数字后缀的列（如 "{{.FieldName}}1"、"{{.FieldName}}2"），或设置字段属性 "optional:true" 表示该字段可缺省'
+  help: '添加列 "{{.FieldName}}1"、"{{.FieldName}}2" 等；或设置属性 "optional:true" 表示字段可缺省'
 # [3000, 3999]: importer error
 E3000:
   desc: no workbook file found about sheet specifier

--- a/internal/x/xerrors/ecode_generated.go
+++ b/internal/x/xerrors/ecode_generated.go
@@ -34,6 +34,7 @@ var ErrE2025 = newEcode("E2025", `version value mismatches pattern`)
 var ErrE2026 = newEcode("E2026", `illegally ordered values`)
 var ErrE2027 = newEcode("E2027", `protovalidate violation`)
 var ErrE2028 = newEcode("E2028", `duplicate elements in incell keyed-list`)
+var ErrE2029 = newEcode("E2029", `no cell found with digit suffix for horizontal list/map field`)
 var ErrE3000 = newEcode("E3000", `no workbook file found about sheet specifier`)
 var ErrE3001 = newEcode("E3001", `no worksheet found in workbook`)
 var ErrE3002 = newEcode("E3002", `failed to open file`)
@@ -323,6 +324,14 @@ func E2027(violation string, fieldValue any) error {
 func E2028(elem any) error {
 	return renderEcode(ErrE2028, map[string]any{
 		"Elem": elem,
+	})
+}
+
+// E2029: no cell found with digit suffix for horizontal list/map field
+func E2029(fieldName string, fieldType string) error {
+	return renderEcode(ErrE2029, map[string]any{
+		"FieldName": fieldName,
+		"FieldType": fieldType,
 	})
 }
 

--- a/internal/x/xerrors/ecode_generated.go
+++ b/internal/x/xerrors/ecode_generated.go
@@ -34,7 +34,7 @@ var ErrE2025 = newEcode("E2025", `version value mismatches pattern`)
 var ErrE2026 = newEcode("E2026", `illegally ordered values`)
 var ErrE2027 = newEcode("E2027", `protovalidate violation`)
 var ErrE2028 = newEcode("E2028", `duplicate elements in incell keyed-list`)
-var ErrE2029 = newEcode("E2029", `no cell found with digit suffix for horizontal list/map field`)
+var ErrE2029 = newEcode("E2029", `no cell with digit suffix for horizontal list/map field`)
 var ErrE3000 = newEcode("E3000", `no workbook file found about sheet specifier`)
 var ErrE3001 = newEcode("E3001", `no worksheet found in workbook`)
 var ErrE3002 = newEcode("E3002", `failed to open file`)
@@ -327,7 +327,7 @@ func E2028(elem any) error {
 	})
 }
 
-// E2029: no cell found with digit suffix for horizontal list/map field
+// E2029: no cell with digit suffix for horizontal list/map field
 func E2029(fieldName string, fieldType string) error {
 	return renderEcode(ErrE2029, map[string]any{
 		"FieldName": fieldName,

--- a/proto/tableau/protobuf/unittest/unittest.proto
+++ b/proto/tableau/protobuf/unittest/unittest.proto
@@ -951,3 +951,25 @@ message HorizontalAggregateList {
     }];
   }
 }
+
+message HorizontalListFieldConf {
+  option (tableau.worksheet) = {
+    name: "HorizontalListFieldConf"
+    namerow: 1
+    typerow: 2
+    noterow: 3
+    datarow: 4
+  };
+
+  map<uint32, Reward> reward_map = 1 [(tableau.field) = {
+    key: "ID"
+    layout: LAYOUT_VERTICAL
+  }];
+  message Reward {
+    uint32 id = 1 [(tableau.field) = {name: "ID"}];
+    repeated unittest.Item item_list = 2 [(tableau.field) = {
+      name: "Item"
+      layout: LAYOUT_HORIZONTAL
+    }];
+  }
+}

--- a/proto/tableaupb/unittestpb/unittest.pb.go
+++ b/proto/tableaupb/unittestpb/unittest.pb.go
@@ -1875,6 +1875,53 @@ func (x *HorizontalAggregateList) GetHeroMap() map[uint32]*HorizontalAggregateLi
 	return nil
 }
 
+type HorizontalListFieldConf struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	RewardMap map[uint32]*HorizontalListFieldConf_Reward `protobuf:"bytes,1,rep,name=reward_map,json=rewardMap,proto3" json:"reward_map,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (x *HorizontalListFieldConf) Reset() {
+	*x = HorizontalListFieldConf{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[34]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *HorizontalListFieldConf) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HorizontalListFieldConf) ProtoMessage() {}
+
+func (x *HorizontalListFieldConf) ProtoReflect() protoreflect.Message {
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[34]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HorizontalListFieldConf.ProtoReflect.Descriptor instead.
+func (*HorizontalListFieldConf) Descriptor() ([]byte, []int) {
+	return file_tableau_protobuf_unittest_unittest_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *HorizontalListFieldConf) GetRewardMap() map[uint32]*HorizontalListFieldConf_Reward {
+	if x != nil {
+		return x.RewardMap
+	}
+	return nil
+}
+
 type IncellMap_Fruit struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1887,7 +1934,7 @@ type IncellMap_Fruit struct {
 func (x *IncellMap_Fruit) Reset() {
 	*x = IncellMap_Fruit{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[36]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[37]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1900,7 +1947,7 @@ func (x *IncellMap_Fruit) String() string {
 func (*IncellMap_Fruit) ProtoMessage() {}
 
 func (x *IncellMap_Fruit) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[36]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[37]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1942,7 +1989,7 @@ type IncellMap_Item struct {
 func (x *IncellMap_Item) Reset() {
 	*x = IncellMap_Item{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[39]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[40]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1955,7 +2002,7 @@ func (x *IncellMap_Item) String() string {
 func (*IncellMap_Item) ProtoMessage() {}
 
 func (x *IncellMap_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[39]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[40]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1997,7 +2044,7 @@ type MallConf_Shop struct {
 func (x *MallConf_Shop) Reset() {
 	*x = MallConf_Shop{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[42]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[43]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2010,7 +2057,7 @@ func (x *MallConf_Shop) String() string {
 func (*MallConf_Shop) ProtoMessage() {}
 
 func (x *MallConf_Shop) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[42]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[43]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2052,7 +2099,7 @@ type MallConf_Shop_Goods struct {
 func (x *MallConf_Shop_Goods) Reset() {
 	*x = MallConf_Shop_Goods{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[44]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[45]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2065,7 +2112,7 @@ func (x *MallConf_Shop_Goods) String() string {
 func (*MallConf_Shop_Goods) ProtoMessage() {}
 
 func (x *MallConf_Shop_Goods) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[44]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[45]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2108,7 +2155,7 @@ type ActivityConf_Activity struct {
 func (x *ActivityConf_Activity) Reset() {
 	*x = ActivityConf_Activity{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[46]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[47]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2121,7 +2168,7 @@ func (x *ActivityConf_Activity) String() string {
 func (*ActivityConf_Activity) ProtoMessage() {}
 
 func (x *ActivityConf_Activity) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[46]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[47]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2171,7 +2218,7 @@ type ActivityConf_Activity_Chapter struct {
 func (x *ActivityConf_Activity_Chapter) Reset() {
 	*x = ActivityConf_Activity_Chapter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[48]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[49]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2184,7 +2231,7 @@ func (x *ActivityConf_Activity_Chapter) String() string {
 func (*ActivityConf_Activity_Chapter) ProtoMessage() {}
 
 func (x *ActivityConf_Activity_Chapter) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[48]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[49]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2234,7 +2281,7 @@ type ActivityConf_Activity_Chapter_Section struct {
 func (x *ActivityConf_Activity_Chapter_Section) Reset() {
 	*x = ActivityConf_Activity_Chapter_Section{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[49]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[50]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2247,7 +2294,7 @@ func (x *ActivityConf_Activity_Chapter_Section) String() string {
 func (*ActivityConf_Activity_Chapter_Section) ProtoMessage() {}
 
 func (x *ActivityConf_Activity_Chapter_Section) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[49]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[50]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2296,7 +2343,7 @@ type ActivityConf_Activity_Chapter_Section_Reward struct {
 func (x *ActivityConf_Activity_Chapter_Section_Reward) Reset() {
 	*x = ActivityConf_Activity_Chapter_Section_Reward{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[51]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[52]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2309,7 +2356,7 @@ func (x *ActivityConf_Activity_Chapter_Section_Reward) String() string {
 func (*ActivityConf_Activity_Chapter_Section_Reward) ProtoMessage() {}
 
 func (x *ActivityConf_Activity_Chapter_Section_Reward) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[51]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[52]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2351,7 +2398,7 @@ type RewardConf_Reward struct {
 func (x *RewardConf_Reward) Reset() {
 	*x = RewardConf_Reward{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[53]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[54]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2364,7 +2411,7 @@ func (x *RewardConf_Reward) String() string {
 func (*RewardConf_Reward) ProtoMessage() {}
 
 func (x *RewardConf_Reward) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[53]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[54]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2406,7 +2453,7 @@ type PatchMergeConf_Time struct {
 func (x *PatchMergeConf_Time) Reset() {
 	*x = PatchMergeConf_Time{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[55]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[56]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2419,7 +2466,7 @@ func (x *PatchMergeConf_Time) String() string {
 func (*PatchMergeConf_Time) ProtoMessage() {}
 
 func (x *PatchMergeConf_Time) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[55]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[56]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2461,7 +2508,7 @@ type RecursivePatchConf_Shop struct {
 func (x *RecursivePatchConf_Shop) Reset() {
 	*x = RecursivePatchConf_Shop{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[59]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[60]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2474,7 +2521,7 @@ func (x *RecursivePatchConf_Shop) String() string {
 func (*RecursivePatchConf_Shop) ProtoMessage() {}
 
 func (x *RecursivePatchConf_Shop) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[59]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[60]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2519,7 +2566,7 @@ type RecursivePatchConf_Shop_Goods struct {
 func (x *RecursivePatchConf_Shop_Goods) Reset() {
 	*x = RecursivePatchConf_Shop_Goods{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[61]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[62]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2532,7 +2579,7 @@ func (x *RecursivePatchConf_Shop_Goods) String() string {
 func (*RecursivePatchConf_Shop_Goods) ProtoMessage() {}
 
 func (x *RecursivePatchConf_Shop_Goods) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[61]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[62]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2597,7 +2644,7 @@ type RecursivePatchConf_Shop_Goods_Currency struct {
 func (x *RecursivePatchConf_Shop_Goods_Currency) Reset() {
 	*x = RecursivePatchConf_Shop_Goods_Currency{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[63]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[64]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2610,7 +2657,7 @@ func (x *RecursivePatchConf_Shop_Goods_Currency) String() string {
 func (*RecursivePatchConf_Shop_Goods_Currency) ProtoMessage() {}
 
 func (x *RecursivePatchConf_Shop_Goods_Currency) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[63]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[64]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2666,7 +2713,7 @@ type RecursivePatchConf_Shop_Goods_Award struct {
 func (x *RecursivePatchConf_Shop_Goods_Award) Reset() {
 	*x = RecursivePatchConf_Shop_Goods_Award{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[64]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[65]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2679,7 +2726,7 @@ func (x *RecursivePatchConf_Shop_Goods_Award) String() string {
 func (*RecursivePatchConf_Shop_Goods_Award) ProtoMessage() {}
 
 func (x *RecursivePatchConf_Shop_Goods_Award) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[64]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[65]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2722,7 +2769,7 @@ type UniqueFieldInVerticalStructList_Item struct {
 func (x *UniqueFieldInVerticalStructList_Item) Reset() {
 	*x = UniqueFieldInVerticalStructList_Item{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[68]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[69]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2735,7 +2782,7 @@ func (x *UniqueFieldInVerticalStructList_Item) String() string {
 func (*UniqueFieldInVerticalStructList_Item) ProtoMessage() {}
 
 func (x *UniqueFieldInVerticalStructList_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[68]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[69]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2786,7 +2833,7 @@ type VerticalUniqueFieldStructMap_Main struct {
 func (x *VerticalUniqueFieldStructMap_Main) Reset() {
 	*x = VerticalUniqueFieldStructMap_Main{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[70]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[71]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2799,7 +2846,7 @@ func (x *VerticalUniqueFieldStructMap_Main) String() string {
 func (*VerticalUniqueFieldStructMap_Main) ProtoMessage() {}
 
 func (x *VerticalUniqueFieldStructMap_Main) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[70]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[71]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2855,7 +2902,7 @@ type VerticalUniqueFieldStructMap_Main_Sub struct {
 func (x *VerticalUniqueFieldStructMap_Main_Sub) Reset() {
 	*x = VerticalUniqueFieldStructMap_Main_Sub{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[73]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[74]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2868,7 +2915,7 @@ func (x *VerticalUniqueFieldStructMap_Main_Sub) String() string {
 func (*VerticalUniqueFieldStructMap_Main_Sub) ProtoMessage() {}
 
 func (x *VerticalUniqueFieldStructMap_Main_Sub) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[73]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[74]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2911,7 +2958,7 @@ type DocumentUniqueFieldStructList_Item struct {
 func (x *DocumentUniqueFieldStructList_Item) Reset() {
 	*x = DocumentUniqueFieldStructList_Item{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[74]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[75]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2924,7 +2971,7 @@ func (x *DocumentUniqueFieldStructList_Item) String() string {
 func (*DocumentUniqueFieldStructList_Item) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructList_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[74]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[75]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2974,7 +3021,7 @@ type DocumentUniqueFieldStructMap_Chapter struct {
 func (x *DocumentUniqueFieldStructMap_Chapter) Reset() {
 	*x = DocumentUniqueFieldStructMap_Chapter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[76]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[77]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -2987,7 +3034,7 @@ func (x *DocumentUniqueFieldStructMap_Chapter) String() string {
 func (*DocumentUniqueFieldStructMap_Chapter) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructMap_Chapter) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[76]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[77]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3037,7 +3084,7 @@ type DocumentUniqueFieldStructMap_ChapterInfo struct {
 func (x *DocumentUniqueFieldStructMap_ChapterInfo) Reset() {
 	*x = DocumentUniqueFieldStructMap_ChapterInfo{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[80]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[81]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3050,7 +3097,7 @@ func (x *DocumentUniqueFieldStructMap_ChapterInfo) String() string {
 func (*DocumentUniqueFieldStructMap_ChapterInfo) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructMap_ChapterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[80]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[81]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3099,7 +3146,7 @@ type DocumentUniqueFieldStructMap_Chapter_Section struct {
 func (x *DocumentUniqueFieldStructMap_Chapter_Section) Reset() {
 	*x = DocumentUniqueFieldStructMap_Chapter_Section{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[82]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[83]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3112,7 +3159,7 @@ func (x *DocumentUniqueFieldStructMap_Chapter_Section) String() string {
 func (*DocumentUniqueFieldStructMap_Chapter_Section) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructMap_Chapter_Section) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[82]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[83]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3155,7 +3202,7 @@ type DocumentUniqueFieldStructMap_ChapterInfo_Section struct {
 func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section) Reset() {
 	*x = DocumentUniqueFieldStructMap_ChapterInfo_Section{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[84]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[85]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3168,7 +3215,7 @@ func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section) String() string {
 func (*DocumentUniqueFieldStructMap_ChapterInfo_Section) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[84]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[85]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3218,7 +3265,7 @@ type DocumentUniqueFieldStructMap_ChapterInfo_Section_Section struct {
 func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section_Section) Reset() {
 	*x = DocumentUniqueFieldStructMap_ChapterInfo_Section_Section{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[86]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[87]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3231,7 +3278,7 @@ func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section_Section) String() stri
 func (*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section_Section) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[86]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[87]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3280,7 +3327,7 @@ type DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section struct {
 func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section) Reset() {
 	*x = DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[88]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[89]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3293,7 +3340,7 @@ func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section) Strin
 func (*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section) ProtoMessage() {}
 
 func (x *DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[88]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[89]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3336,7 +3383,7 @@ type SequenceFieldInVerticalStructList_Item struct {
 func (x *SequenceFieldInVerticalStructList_Item) Reset() {
 	*x = SequenceFieldInVerticalStructList_Item{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[89]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[90]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3349,7 +3396,7 @@ func (x *SequenceFieldInVerticalStructList_Item) String() string {
 func (*SequenceFieldInVerticalStructList_Item) ProtoMessage() {}
 
 func (x *SequenceFieldInVerticalStructList_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[89]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[90]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3398,7 +3445,7 @@ type SequenceKeyInVerticalKeyedList_Item struct {
 func (x *SequenceKeyInVerticalKeyedList_Item) Reset() {
 	*x = SequenceKeyInVerticalKeyedList_Item{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[90]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[91]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3411,7 +3458,7 @@ func (x *SequenceKeyInVerticalKeyedList_Item) String() string {
 func (*SequenceKeyInVerticalKeyedList_Item) ProtoMessage() {}
 
 func (x *SequenceKeyInVerticalKeyedList_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[90]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[91]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3453,7 +3500,7 @@ type SequenceKeyInVerticalKeyedList_Item_Prop struct {
 func (x *SequenceKeyInVerticalKeyedList_Item_Prop) Reset() {
 	*x = SequenceKeyInVerticalKeyedList_Item_Prop{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[92]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[93]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3466,7 +3513,7 @@ func (x *SequenceKeyInVerticalKeyedList_Item_Prop) String() string {
 func (*SequenceKeyInVerticalKeyedList_Item_Prop) ProtoMessage() {}
 
 func (x *SequenceKeyInVerticalKeyedList_Item_Prop) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[92]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[93]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3508,7 +3555,7 @@ type VerticalSequenceFieldStructMap_Main struct {
 func (x *VerticalSequenceFieldStructMap_Main) Reset() {
 	*x = VerticalSequenceFieldStructMap_Main{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[94]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[95]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3521,7 +3568,7 @@ func (x *VerticalSequenceFieldStructMap_Main) String() string {
 func (*VerticalSequenceFieldStructMap_Main) ProtoMessage() {}
 
 func (x *VerticalSequenceFieldStructMap_Main) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[94]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[95]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3563,7 +3610,7 @@ type VerticalSequenceFieldStructMap_Main_Sub struct {
 func (x *VerticalSequenceFieldStructMap_Main_Sub) Reset() {
 	*x = VerticalSequenceFieldStructMap_Main_Sub{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[96]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[97]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3576,7 +3623,7 @@ func (x *VerticalSequenceFieldStructMap_Main_Sub) String() string {
 func (*VerticalSequenceFieldStructMap_Main_Sub) ProtoMessage() {}
 
 func (x *VerticalSequenceFieldStructMap_Main_Sub) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[96]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[97]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3619,7 +3666,7 @@ type DocumentSequenceFieldStructList_Item struct {
 func (x *DocumentSequenceFieldStructList_Item) Reset() {
 	*x = DocumentSequenceFieldStructList_Item{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[97]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[98]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3632,7 +3679,7 @@ func (x *DocumentSequenceFieldStructList_Item) String() string {
 func (*DocumentSequenceFieldStructList_Item) ProtoMessage() {}
 
 func (x *DocumentSequenceFieldStructList_Item) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[97]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[98]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3681,7 +3728,7 @@ type Transpose_Hero struct {
 func (x *Transpose_Hero) Reset() {
 	*x = Transpose_Hero{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[99]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[100]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3694,7 +3741,7 @@ func (x *Transpose_Hero) String() string {
 func (*Transpose_Hero) ProtoMessage() {}
 
 func (x *Transpose_Hero) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[99]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[100]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3736,7 +3783,7 @@ type TaskConf_Task struct {
 func (x *TaskConf_Task) Reset() {
 	*x = TaskConf_Task{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[102]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[103]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3749,7 +3796,7 @@ func (x *TaskConf_Task) String() string {
 func (*TaskConf_Task) ProtoMessage() {}
 
 func (x *TaskConf_Task) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[102]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[103]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3795,7 +3842,7 @@ type FieldPresentMap_Player struct {
 func (x *FieldPresentMap_Player) Reset() {
 	*x = FieldPresentMap_Player{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[104]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[105]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3808,7 +3855,7 @@ func (x *FieldPresentMap_Player) String() string {
 func (*FieldPresentMap_Player) ProtoMessage() {}
 
 func (x *FieldPresentMap_Player) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[104]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[105]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3878,7 +3925,7 @@ type FieldPresentMap_Player_Weapon struct {
 func (x *FieldPresentMap_Player_Weapon) Reset() {
 	*x = FieldPresentMap_Player_Weapon{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[105]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[106]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3891,7 +3938,7 @@ func (x *FieldPresentMap_Player_Weapon) String() string {
 func (*FieldPresentMap_Player_Weapon) ProtoMessage() {}
 
 func (x *FieldPresentMap_Player_Weapon) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[105]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[106]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3933,7 +3980,7 @@ type FieldPresentMap_Player_Info struct {
 func (x *FieldPresentMap_Player_Info) Reset() {
 	*x = FieldPresentMap_Player_Info{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[106]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[107]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -3946,7 +3993,7 @@ func (x *FieldPresentMap_Player_Info) String() string {
 func (*FieldPresentMap_Player_Info) ProtoMessage() {}
 
 func (x *FieldPresentMap_Player_Info) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[106]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[107]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3988,7 +4035,7 @@ type ScatterNoneConf_Zone struct {
 func (x *ScatterNoneConf_Zone) Reset() {
 	*x = ScatterNoneConf_Zone{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[109]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[110]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4001,7 +4048,7 @@ func (x *ScatterNoneConf_Zone) String() string {
 func (*ScatterNoneConf_Zone) ProtoMessage() {}
 
 func (x *ScatterNoneConf_Zone) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[109]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[110]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4043,7 +4090,7 @@ type ScatterReplaceConf_Zone struct {
 func (x *ScatterReplaceConf_Zone) Reset() {
 	*x = ScatterReplaceConf_Zone{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[111]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[112]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4056,7 +4103,7 @@ func (x *ScatterReplaceConf_Zone) String() string {
 func (*ScatterReplaceConf_Zone) ProtoMessage() {}
 
 func (x *ScatterReplaceConf_Zone) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[111]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[112]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4098,7 +4145,7 @@ type ScatterMergeConf_Zone struct {
 func (x *ScatterMergeConf_Zone) Reset() {
 	*x = ScatterMergeConf_Zone{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[113]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[114]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4111,7 +4158,7 @@ func (x *ScatterMergeConf_Zone) String() string {
 func (*ScatterMergeConf_Zone) ProtoMessage() {}
 
 func (x *ScatterMergeConf_Zone) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[113]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[114]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4153,7 +4200,7 @@ type MergerSingleConf_Zone struct {
 func (x *MergerSingleConf_Zone) Reset() {
 	*x = MergerSingleConf_Zone{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[115]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[116]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4166,7 +4213,7 @@ func (x *MergerSingleConf_Zone) String() string {
 func (*MergerSingleConf_Zone) ProtoMessage() {}
 
 func (x *MergerSingleConf_Zone) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[115]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[116]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4208,7 +4255,7 @@ type MergerMultiConf_Zone struct {
 func (x *MergerMultiConf_Zone) Reset() {
 	*x = MergerMultiConf_Zone{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[117]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[118]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4221,7 +4268,7 @@ func (x *MergerMultiConf_Zone) String() string {
 func (*MergerMultiConf_Zone) ProtoMessage() {}
 
 func (x *MergerMultiConf_Zone) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[117]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[118]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4264,7 +4311,7 @@ type VerticalAggregationMap_Hero struct {
 func (x *VerticalAggregationMap_Hero) Reset() {
 	*x = VerticalAggregationMap_Hero{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[119]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[120]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4277,7 +4324,7 @@ func (x *VerticalAggregationMap_Hero) String() string {
 func (*VerticalAggregationMap_Hero) ProtoMessage() {}
 
 func (x *VerticalAggregationMap_Hero) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[119]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[120]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4326,7 +4373,7 @@ type VerticalAggregationMap_Hero_Level struct {
 func (x *VerticalAggregationMap_Hero_Level) Reset() {
 	*x = VerticalAggregationMap_Hero_Level{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[121]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[122]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4339,7 +4386,7 @@ func (x *VerticalAggregationMap_Hero_Level) String() string {
 func (*VerticalAggregationMap_Hero_Level) ProtoMessage() {}
 
 func (x *VerticalAggregationMap_Hero_Level) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[121]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[122]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4381,7 +4428,7 @@ type HorizontalAggregateMap_Hero struct {
 func (x *HorizontalAggregateMap_Hero) Reset() {
 	*x = HorizontalAggregateMap_Hero{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[123]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[124]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4394,7 +4441,7 @@ func (x *HorizontalAggregateMap_Hero) String() string {
 func (*HorizontalAggregateMap_Hero) ProtoMessage() {}
 
 func (x *HorizontalAggregateMap_Hero) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[123]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[124]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4436,7 +4483,7 @@ type HorizontalAggregateList_Hero struct {
 func (x *HorizontalAggregateList_Hero) Reset() {
 	*x = HorizontalAggregateList_Hero{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[126]
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[127]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -4449,7 +4496,7 @@ func (x *HorizontalAggregateList_Hero) String() string {
 func (*HorizontalAggregateList_Hero) ProtoMessage() {}
 
 func (x *HorizontalAggregateList_Hero) ProtoReflect() protoreflect.Message {
-	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[126]
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[127]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4475,6 +4522,61 @@ func (x *HorizontalAggregateList_Hero) GetHeroId() uint32 {
 func (x *HorizontalAggregateList_Hero) GetParamList() []*Item {
 	if x != nil {
 		return x.ParamList
+	}
+	return nil
+}
+
+type HorizontalListFieldConf_Reward struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id       uint32  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	ItemList []*Item `protobuf:"bytes,2,rep,name=item_list,json=itemList,proto3" json:"item_list,omitempty"`
+}
+
+func (x *HorizontalListFieldConf_Reward) Reset() {
+	*x = HorizontalListFieldConf_Reward{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[129]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *HorizontalListFieldConf_Reward) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HorizontalListFieldConf_Reward) ProtoMessage() {}
+
+func (x *HorizontalListFieldConf_Reward) ProtoReflect() protoreflect.Message {
+	mi := &file_tableau_protobuf_unittest_unittest_proto_msgTypes[129]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HorizontalListFieldConf_Reward.ProtoReflect.Descriptor instead.
+func (*HorizontalListFieldConf_Reward) Descriptor() ([]byte, []int) {
+	return file_tableau_protobuf_unittest_unittest_proto_rawDescGZIP(), []int{34, 1}
+}
+
+func (x *HorizontalListFieldConf_Reward) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *HorizontalListFieldConf_Reward) GetItemList() []*Item {
+	if x != nil {
+		return x.ItemList
 	}
 	return nil
 }
@@ -5571,13 +5673,35 @@ var file_tableau_protobuf_unittest_unittest_proto_rawDesc = []byte{
 	0x52, 0x09, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x4c, 0x69, 0x73, 0x74, 0x3a, 0x25, 0x82, 0xb5, 0x18,
 	0x21, 0x0a, 0x17, 0x48, 0x6f, 0x72, 0x69, 0x7a, 0x6f, 0x6e, 0x74, 0x61, 0x6c, 0x41, 0x67, 0x67,
 	0x72, 0x65, 0x67, 0x61, 0x74, 0x65, 0x4c, 0x69, 0x73, 0x74, 0x10, 0x01, 0x18, 0x02, 0x20, 0x03,
-	0x28, 0x04, 0x42, 0x56, 0x82, 0xb5, 0x18, 0x19, 0x0a, 0x17, 0x75, 0x6e, 0x69, 0x74, 0x74, 0x65,
-	0x73, 0x74, 0x2f, 0x55, 0x6e, 0x69, 0x74, 0x74, 0x65, 0x73, 0x74, 0x23, 0x2a, 0x2e, 0x63, 0x73,
-	0x76, 0x5a, 0x37, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x61,
-	0x62, 0x6c, 0x65, 0x61, 0x75, 0x69, 0x6f, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x61, 0x75, 0x2f,
-	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x61, 0x75, 0x70, 0x62, 0x2f,
-	0x75, 0x6e, 0x69, 0x74, 0x74, 0x65, 0x73, 0x74, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74,
-	0x6f, 0x33,
+	0x28, 0x04, 0x22, 0xe4, 0x02, 0x0a, 0x17, 0x48, 0x6f, 0x72, 0x69, 0x7a, 0x6f, 0x6e, 0x74, 0x61,
+	0x6c, 0x4c, 0x69, 0x73, 0x74, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e, 0x66, 0x12, 0x5b,
+	0x0a, 0x0a, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x5f, 0x6d, 0x61, 0x70, 0x18, 0x01, 0x20, 0x03,
+	0x28, 0x0b, 0x32, 0x30, 0x2e, 0x75, 0x6e, 0x69, 0x74, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x48, 0x6f,
+	0x72, 0x69, 0x7a, 0x6f, 0x6e, 0x74, 0x61, 0x6c, 0x4c, 0x69, 0x73, 0x74, 0x46, 0x69, 0x65, 0x6c,
+	0x64, 0x43, 0x6f, 0x6e, 0x66, 0x2e, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x4d, 0x61, 0x70, 0x45,
+	0x6e, 0x74, 0x72, 0x79, 0x42, 0x0a, 0x82, 0xb5, 0x18, 0x06, 0x1a, 0x02, 0x49, 0x44, 0x20, 0x01,
+	0x52, 0x09, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x4d, 0x61, 0x70, 0x1a, 0x66, 0x0a, 0x0e, 0x52,
+	0x65, 0x77, 0x61, 0x72, 0x64, 0x4d, 0x61, 0x70, 0x45, 0x6e, 0x74, 0x72, 0x79, 0x12, 0x10, 0x0a,
+	0x03, 0x6b, 0x65, 0x79, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x12,
+	0x3e, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x28,
+	0x2e, 0x75, 0x6e, 0x69, 0x74, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x48, 0x6f, 0x72, 0x69, 0x7a, 0x6f,
+	0x6e, 0x74, 0x61, 0x6c, 0x4c, 0x69, 0x73, 0x74, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e,
+	0x66, 0x2e, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x3a,
+	0x02, 0x38, 0x01, 0x1a, 0x5d, 0x0a, 0x06, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x12, 0x18, 0x0a,
+	0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0d, 0x42, 0x08, 0x82, 0xb5, 0x18, 0x04, 0x0a,
+	0x02, 0x49, 0x44, 0x52, 0x02, 0x69, 0x64, 0x12, 0x39, 0x0a, 0x09, 0x69, 0x74, 0x65, 0x6d, 0x5f,
+	0x6c, 0x69, 0x73, 0x74, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x0e, 0x2e, 0x75, 0x6e, 0x69,
+	0x74, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x49, 0x74, 0x65, 0x6d, 0x42, 0x0c, 0x82, 0xb5, 0x18, 0x08,
+	0x0a, 0x04, 0x49, 0x74, 0x65, 0x6d, 0x20, 0x02, 0x52, 0x08, 0x69, 0x74, 0x65, 0x6d, 0x4c, 0x69,
+	0x73, 0x74, 0x3a, 0x25, 0x82, 0xb5, 0x18, 0x21, 0x0a, 0x17, 0x48, 0x6f, 0x72, 0x69, 0x7a, 0x6f,
+	0x6e, 0x74, 0x61, 0x6c, 0x4c, 0x69, 0x73, 0x74, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x43, 0x6f, 0x6e,
+	0x66, 0x10, 0x01, 0x18, 0x02, 0x20, 0x03, 0x28, 0x04, 0x42, 0x56, 0x82, 0xb5, 0x18, 0x19, 0x0a,
+	0x17, 0x75, 0x6e, 0x69, 0x74, 0x74, 0x65, 0x73, 0x74, 0x2f, 0x55, 0x6e, 0x69, 0x74, 0x74, 0x65,
+	0x73, 0x74, 0x23, 0x2a, 0x2e, 0x63, 0x73, 0x76, 0x5a, 0x37, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
+	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x61, 0x75, 0x69, 0x6f, 0x2f, 0x74,
+	0x61, 0x62, 0x6c, 0x65, 0x61, 0x75, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x74, 0x61, 0x62,
+	0x6c, 0x65, 0x61, 0x75, 0x70, 0x62, 0x2f, 0x75, 0x6e, 0x69, 0x74, 0x74, 0x65, 0x73, 0x74, 0x70,
+	0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -5592,7 +5716,7 @@ func file_tableau_protobuf_unittest_unittest_proto_rawDescGZIP() []byte {
 	return file_tableau_protobuf_unittest_unittest_proto_rawDescData
 }
 
-var file_tableau_protobuf_unittest_unittest_proto_msgTypes = make([]protoimpl.MessageInfo, 127)
+var file_tableau_protobuf_unittest_unittest_proto_msgTypes = make([]protoimpl.MessageInfo, 130)
 var file_tableau_protobuf_unittest_unittest_proto_goTypes = []interface{}{
 	(*SimpleIncellMap)(nil),                   // 0: unittest.SimpleIncellMap
 	(*IncellMap)(nil),                         // 1: unittest.IncellMap
@@ -5628,227 +5752,233 @@ var file_tableau_protobuf_unittest_unittest_proto_goTypes = []interface{}{
 	(*IncellKeyedList)(nil),                   // 31: unittest.IncellKeyedList
 	(*HorizontalAggregateMap)(nil),            // 32: unittest.HorizontalAggregateMap
 	(*HorizontalAggregateList)(nil),           // 33: unittest.HorizontalAggregateList
-	nil,                                       // 34: unittest.SimpleIncellMap.ItemMapEntry
-	nil,                                       // 35: unittest.IncellMap.FruitMapEntry
-	(*IncellMap_Fruit)(nil),                   // 36: unittest.IncellMap.Fruit
-	nil,                                       // 37: unittest.IncellMap.FlavorMapEntry
-	nil,                                       // 38: unittest.IncellMap.ItemMapEntry
-	(*IncellMap_Item)(nil),                    // 39: unittest.IncellMap.Item
-	nil,                                       // 40: unittest.ItemConf.ItemMapEntry
-	nil,                                       // 41: unittest.MallConf.ShopMapEntry
-	(*MallConf_Shop)(nil),                     // 42: unittest.MallConf.Shop
-	nil,                                       // 43: unittest.MallConf.Shop.GoodsMapEntry
-	(*MallConf_Shop_Goods)(nil),               // 44: unittest.MallConf.Shop.Goods
-	nil,                                       // 45: unittest.ActivityConf.ActivityMapEntry
-	(*ActivityConf_Activity)(nil),             // 46: unittest.ActivityConf.Activity
-	nil,                                       // 47: unittest.ActivityConf.Activity.ChapterMapEntry
-	(*ActivityConf_Activity_Chapter)(nil),     // 48: unittest.ActivityConf.Activity.Chapter
-	(*ActivityConf_Activity_Chapter_Section)(nil), // 49: unittest.ActivityConf.Activity.Chapter.Section
-	nil, // 50: unittest.ActivityConf.Activity.Chapter.Section.RewardMapEntry
-	(*ActivityConf_Activity_Chapter_Section_Reward)(nil), // 51: unittest.ActivityConf.Activity.Chapter.Section.Reward
-	nil,                                   // 52: unittest.RewardConf.RewardMapEntry
-	(*RewardConf_Reward)(nil),             // 53: unittest.RewardConf.Reward
-	nil,                                   // 54: unittest.RewardConf.Reward.ItemMapEntry
-	(*PatchMergeConf_Time)(nil),           // 55: unittest.PatchMergeConf.Time
-	nil,                                   // 56: unittest.PatchMergeConf.ItemMapEntry
-	nil,                                   // 57: unittest.PatchMergeConf.ReplaceItemMapEntry
-	nil,                                   // 58: unittest.RecursivePatchConf.ShopMapEntry
-	(*RecursivePatchConf_Shop)(nil),       // 59: unittest.RecursivePatchConf.Shop
-	nil,                                   // 60: unittest.RecursivePatchConf.Shop.GoodsMapEntry
-	(*RecursivePatchConf_Shop_Goods)(nil), // 61: unittest.RecursivePatchConf.Shop.Goods
-	nil,                                   // 62: unittest.RecursivePatchConf.Shop.Goods.CurrencyMapEntry
-	(*RecursivePatchConf_Shop_Goods_Currency)(nil), // 63: unittest.RecursivePatchConf.Shop.Goods.Currency
-	(*RecursivePatchConf_Shop_Goods_Award)(nil),    // 64: unittest.RecursivePatchConf.Shop.Goods.Award
-	nil, // 65: unittest.RecursivePatchConf.Shop.Goods.Currency.ValueListEntry
-	nil, // 66: unittest.RecursivePatchConf.Shop.Goods.Currency.MessageListEntry
-	nil, // 67: unittest.JsonUtilTestData.MapFieldEntry
-	(*UniqueFieldInVerticalStructList_Item)(nil), // 68: unittest.UniqueFieldInVerticalStructList.Item
-	nil, // 69: unittest.VerticalUniqueFieldStructMap.MainMapEntry
-	(*VerticalUniqueFieldStructMap_Main)(nil), // 70: unittest.VerticalUniqueFieldStructMap.Main
-	nil, // 71: unittest.VerticalUniqueFieldStructMap.Main.MainKvMapEntry
-	nil, // 72: unittest.VerticalUniqueFieldStructMap.Main.SubMapEntry
-	(*VerticalUniqueFieldStructMap_Main_Sub)(nil), // 73: unittest.VerticalUniqueFieldStructMap.Main.Sub
-	(*DocumentUniqueFieldStructList_Item)(nil),    // 74: unittest.DocumentUniqueFieldStructList.Item
-	nil, // 75: unittest.DocumentUniqueFieldStructMap.ChapterEntry
-	(*DocumentUniqueFieldStructMap_Chapter)(nil), // 76: unittest.DocumentUniqueFieldStructMap.Chapter
-	nil, // 77: unittest.DocumentUniqueFieldStructMap.ScalarMapEntry
-	nil, // 78: unittest.DocumentUniqueFieldStructMap.IncellMapEntry
-	nil, // 79: unittest.DocumentUniqueFieldStructMap.ChapterInfoEntry
-	(*DocumentUniqueFieldStructMap_ChapterInfo)(nil), // 80: unittest.DocumentUniqueFieldStructMap.ChapterInfo
-	nil, // 81: unittest.DocumentUniqueFieldStructMap.Chapter.SectionEntry
-	(*DocumentUniqueFieldStructMap_Chapter_Section)(nil), // 82: unittest.DocumentUniqueFieldStructMap.Chapter.Section
-	nil, // 83: unittest.DocumentUniqueFieldStructMap.ChapterInfo.SectionEntry
-	(*DocumentUniqueFieldStructMap_ChapterInfo_Section)(nil), // 84: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section
-	nil, // 85: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.SectionEntry
-	(*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section)(nil), // 86: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section
-	nil, // 87: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.SectionEntry
-	(*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section)(nil), // 88: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.Section
-	(*SequenceFieldInVerticalStructList_Item)(nil),                           // 89: unittest.SequenceFieldInVerticalStructList.Item
-	(*SequenceKeyInVerticalKeyedList_Item)(nil),                              // 90: unittest.SequenceKeyInVerticalKeyedList.Item
-	nil, // 91: unittest.SequenceKeyInVerticalKeyedList.Item.PropMapEntry
-	(*SequenceKeyInVerticalKeyedList_Item_Prop)(nil), // 92: unittest.SequenceKeyInVerticalKeyedList.Item.Prop
-	nil, // 93: unittest.VerticalSequenceFieldStructMap.MainMapEntry
-	(*VerticalSequenceFieldStructMap_Main)(nil), // 94: unittest.VerticalSequenceFieldStructMap.Main
-	nil, // 95: unittest.VerticalSequenceFieldStructMap.Main.SubMapEntry
-	(*VerticalSequenceFieldStructMap_Main_Sub)(nil), // 96: unittest.VerticalSequenceFieldStructMap.Main.Sub
-	(*DocumentSequenceFieldStructList_Item)(nil),    // 97: unittest.DocumentSequenceFieldStructList.Item
-	nil,                                   // 98: unittest.Transpose.HeroMapEntry
-	(*Transpose_Hero)(nil),                // 99: unittest.Transpose.Hero
-	nil,                                   // 100: unittest.ValidateConf.PropMapEntry
-	nil,                                   // 101: unittest.TaskConf.TaskMapEntry
-	(*TaskConf_Task)(nil),                 // 102: unittest.TaskConf.Task
-	nil,                                   // 103: unittest.FieldPresentMap.PlayerMapEntry
-	(*FieldPresentMap_Player)(nil),        // 104: unittest.FieldPresentMap.Player
-	(*FieldPresentMap_Player_Weapon)(nil), // 105: unittest.FieldPresentMap.Player.Weapon
-	(*FieldPresentMap_Player_Info)(nil),   // 106: unittest.FieldPresentMap.Player.Info
-	nil,                                   // 107: unittest.FieldPresentMap.Player.AttrMapEntry
-	nil,                                   // 108: unittest.ScatterNoneConf.ZoneMapEntry
-	(*ScatterNoneConf_Zone)(nil),          // 109: unittest.ScatterNoneConf.Zone
-	nil,                                   // 110: unittest.ScatterReplaceConf.ZoneMapEntry
-	(*ScatterReplaceConf_Zone)(nil),       // 111: unittest.ScatterReplaceConf.Zone
-	nil,                                   // 112: unittest.ScatterMergeConf.ZoneMapEntry
-	(*ScatterMergeConf_Zone)(nil),         // 113: unittest.ScatterMergeConf.Zone
-	nil,                                   // 114: unittest.MergerSingleConf.ZoneMapEntry
-	(*MergerSingleConf_Zone)(nil),         // 115: unittest.MergerSingleConf.Zone
-	nil,                                   // 116: unittest.MergerMultiConf.ZoneMapEntry
-	(*MergerMultiConf_Zone)(nil),          // 117: unittest.MergerMultiConf.Zone
-	nil,                                   // 118: unittest.VerticalAggregationMap.HeroMapEntry
-	(*VerticalAggregationMap_Hero)(nil),   // 119: unittest.VerticalAggregationMap.Hero
-	nil,                                   // 120: unittest.VerticalAggregationMap.Hero.LevelMapEntry
-	(*VerticalAggregationMap_Hero_Level)(nil), // 121: unittest.VerticalAggregationMap.Hero.Level
-	nil,                                  // 122: unittest.HorizontalAggregateMap.HeroMapEntry
-	(*HorizontalAggregateMap_Hero)(nil),  // 123: unittest.HorizontalAggregateMap.Hero
-	nil,                                  // 124: unittest.HorizontalAggregateMap.Hero.ItemMapEntry
-	nil,                                  // 125: unittest.HorizontalAggregateList.HeroMapEntry
-	(*HorizontalAggregateList_Hero)(nil), // 126: unittest.HorizontalAggregateList.Hero
-	(*Item)(nil),                         // 127: unittest.Item
-	(FruitFlavor)(0),                     // 128: unittest.FruitFlavor
-	(FruitType)(0),                       // 129: unittest.FruitType
-	(*timestamppb.Timestamp)(nil),        // 130: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),          // 131: google.protobuf.Duration
-	(*Target)(nil),                       // 132: unittest.Target
+	(*HorizontalListFieldConf)(nil),           // 34: unittest.HorizontalListFieldConf
+	nil,                                       // 35: unittest.SimpleIncellMap.ItemMapEntry
+	nil,                                       // 36: unittest.IncellMap.FruitMapEntry
+	(*IncellMap_Fruit)(nil),                   // 37: unittest.IncellMap.Fruit
+	nil,                                       // 38: unittest.IncellMap.FlavorMapEntry
+	nil,                                       // 39: unittest.IncellMap.ItemMapEntry
+	(*IncellMap_Item)(nil),                    // 40: unittest.IncellMap.Item
+	nil,                                       // 41: unittest.ItemConf.ItemMapEntry
+	nil,                                       // 42: unittest.MallConf.ShopMapEntry
+	(*MallConf_Shop)(nil),                     // 43: unittest.MallConf.Shop
+	nil,                                       // 44: unittest.MallConf.Shop.GoodsMapEntry
+	(*MallConf_Shop_Goods)(nil),               // 45: unittest.MallConf.Shop.Goods
+	nil,                                       // 46: unittest.ActivityConf.ActivityMapEntry
+	(*ActivityConf_Activity)(nil),             // 47: unittest.ActivityConf.Activity
+	nil,                                       // 48: unittest.ActivityConf.Activity.ChapterMapEntry
+	(*ActivityConf_Activity_Chapter)(nil),     // 49: unittest.ActivityConf.Activity.Chapter
+	(*ActivityConf_Activity_Chapter_Section)(nil), // 50: unittest.ActivityConf.Activity.Chapter.Section
+	nil, // 51: unittest.ActivityConf.Activity.Chapter.Section.RewardMapEntry
+	(*ActivityConf_Activity_Chapter_Section_Reward)(nil), // 52: unittest.ActivityConf.Activity.Chapter.Section.Reward
+	nil,                                   // 53: unittest.RewardConf.RewardMapEntry
+	(*RewardConf_Reward)(nil),             // 54: unittest.RewardConf.Reward
+	nil,                                   // 55: unittest.RewardConf.Reward.ItemMapEntry
+	(*PatchMergeConf_Time)(nil),           // 56: unittest.PatchMergeConf.Time
+	nil,                                   // 57: unittest.PatchMergeConf.ItemMapEntry
+	nil,                                   // 58: unittest.PatchMergeConf.ReplaceItemMapEntry
+	nil,                                   // 59: unittest.RecursivePatchConf.ShopMapEntry
+	(*RecursivePatchConf_Shop)(nil),       // 60: unittest.RecursivePatchConf.Shop
+	nil,                                   // 61: unittest.RecursivePatchConf.Shop.GoodsMapEntry
+	(*RecursivePatchConf_Shop_Goods)(nil), // 62: unittest.RecursivePatchConf.Shop.Goods
+	nil,                                   // 63: unittest.RecursivePatchConf.Shop.Goods.CurrencyMapEntry
+	(*RecursivePatchConf_Shop_Goods_Currency)(nil), // 64: unittest.RecursivePatchConf.Shop.Goods.Currency
+	(*RecursivePatchConf_Shop_Goods_Award)(nil),    // 65: unittest.RecursivePatchConf.Shop.Goods.Award
+	nil, // 66: unittest.RecursivePatchConf.Shop.Goods.Currency.ValueListEntry
+	nil, // 67: unittest.RecursivePatchConf.Shop.Goods.Currency.MessageListEntry
+	nil, // 68: unittest.JsonUtilTestData.MapFieldEntry
+	(*UniqueFieldInVerticalStructList_Item)(nil), // 69: unittest.UniqueFieldInVerticalStructList.Item
+	nil, // 70: unittest.VerticalUniqueFieldStructMap.MainMapEntry
+	(*VerticalUniqueFieldStructMap_Main)(nil), // 71: unittest.VerticalUniqueFieldStructMap.Main
+	nil, // 72: unittest.VerticalUniqueFieldStructMap.Main.MainKvMapEntry
+	nil, // 73: unittest.VerticalUniqueFieldStructMap.Main.SubMapEntry
+	(*VerticalUniqueFieldStructMap_Main_Sub)(nil), // 74: unittest.VerticalUniqueFieldStructMap.Main.Sub
+	(*DocumentUniqueFieldStructList_Item)(nil),    // 75: unittest.DocumentUniqueFieldStructList.Item
+	nil, // 76: unittest.DocumentUniqueFieldStructMap.ChapterEntry
+	(*DocumentUniqueFieldStructMap_Chapter)(nil), // 77: unittest.DocumentUniqueFieldStructMap.Chapter
+	nil, // 78: unittest.DocumentUniqueFieldStructMap.ScalarMapEntry
+	nil, // 79: unittest.DocumentUniqueFieldStructMap.IncellMapEntry
+	nil, // 80: unittest.DocumentUniqueFieldStructMap.ChapterInfoEntry
+	(*DocumentUniqueFieldStructMap_ChapterInfo)(nil), // 81: unittest.DocumentUniqueFieldStructMap.ChapterInfo
+	nil, // 82: unittest.DocumentUniqueFieldStructMap.Chapter.SectionEntry
+	(*DocumentUniqueFieldStructMap_Chapter_Section)(nil), // 83: unittest.DocumentUniqueFieldStructMap.Chapter.Section
+	nil, // 84: unittest.DocumentUniqueFieldStructMap.ChapterInfo.SectionEntry
+	(*DocumentUniqueFieldStructMap_ChapterInfo_Section)(nil), // 85: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section
+	nil, // 86: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.SectionEntry
+	(*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section)(nil), // 87: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section
+	nil, // 88: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.SectionEntry
+	(*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section)(nil), // 89: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.Section
+	(*SequenceFieldInVerticalStructList_Item)(nil),                           // 90: unittest.SequenceFieldInVerticalStructList.Item
+	(*SequenceKeyInVerticalKeyedList_Item)(nil),                              // 91: unittest.SequenceKeyInVerticalKeyedList.Item
+	nil, // 92: unittest.SequenceKeyInVerticalKeyedList.Item.PropMapEntry
+	(*SequenceKeyInVerticalKeyedList_Item_Prop)(nil), // 93: unittest.SequenceKeyInVerticalKeyedList.Item.Prop
+	nil, // 94: unittest.VerticalSequenceFieldStructMap.MainMapEntry
+	(*VerticalSequenceFieldStructMap_Main)(nil), // 95: unittest.VerticalSequenceFieldStructMap.Main
+	nil, // 96: unittest.VerticalSequenceFieldStructMap.Main.SubMapEntry
+	(*VerticalSequenceFieldStructMap_Main_Sub)(nil), // 97: unittest.VerticalSequenceFieldStructMap.Main.Sub
+	(*DocumentSequenceFieldStructList_Item)(nil),    // 98: unittest.DocumentSequenceFieldStructList.Item
+	nil,                                   // 99: unittest.Transpose.HeroMapEntry
+	(*Transpose_Hero)(nil),                // 100: unittest.Transpose.Hero
+	nil,                                   // 101: unittest.ValidateConf.PropMapEntry
+	nil,                                   // 102: unittest.TaskConf.TaskMapEntry
+	(*TaskConf_Task)(nil),                 // 103: unittest.TaskConf.Task
+	nil,                                   // 104: unittest.FieldPresentMap.PlayerMapEntry
+	(*FieldPresentMap_Player)(nil),        // 105: unittest.FieldPresentMap.Player
+	(*FieldPresentMap_Player_Weapon)(nil), // 106: unittest.FieldPresentMap.Player.Weapon
+	(*FieldPresentMap_Player_Info)(nil),   // 107: unittest.FieldPresentMap.Player.Info
+	nil,                                   // 108: unittest.FieldPresentMap.Player.AttrMapEntry
+	nil,                                   // 109: unittest.ScatterNoneConf.ZoneMapEntry
+	(*ScatterNoneConf_Zone)(nil),          // 110: unittest.ScatterNoneConf.Zone
+	nil,                                   // 111: unittest.ScatterReplaceConf.ZoneMapEntry
+	(*ScatterReplaceConf_Zone)(nil),       // 112: unittest.ScatterReplaceConf.Zone
+	nil,                                   // 113: unittest.ScatterMergeConf.ZoneMapEntry
+	(*ScatterMergeConf_Zone)(nil),         // 114: unittest.ScatterMergeConf.Zone
+	nil,                                   // 115: unittest.MergerSingleConf.ZoneMapEntry
+	(*MergerSingleConf_Zone)(nil),         // 116: unittest.MergerSingleConf.Zone
+	nil,                                   // 117: unittest.MergerMultiConf.ZoneMapEntry
+	(*MergerMultiConf_Zone)(nil),          // 118: unittest.MergerMultiConf.Zone
+	nil,                                   // 119: unittest.VerticalAggregationMap.HeroMapEntry
+	(*VerticalAggregationMap_Hero)(nil),   // 120: unittest.VerticalAggregationMap.Hero
+	nil,                                   // 121: unittest.VerticalAggregationMap.Hero.LevelMapEntry
+	(*VerticalAggregationMap_Hero_Level)(nil), // 122: unittest.VerticalAggregationMap.Hero.Level
+	nil,                                    // 123: unittest.HorizontalAggregateMap.HeroMapEntry
+	(*HorizontalAggregateMap_Hero)(nil),    // 124: unittest.HorizontalAggregateMap.Hero
+	nil,                                    // 125: unittest.HorizontalAggregateMap.Hero.ItemMapEntry
+	nil,                                    // 126: unittest.HorizontalAggregateList.HeroMapEntry
+	(*HorizontalAggregateList_Hero)(nil),   // 127: unittest.HorizontalAggregateList.Hero
+	nil,                                    // 128: unittest.HorizontalListFieldConf.RewardMapEntry
+	(*HorizontalListFieldConf_Reward)(nil), // 129: unittest.HorizontalListFieldConf.Reward
+	(*Item)(nil),                           // 130: unittest.Item
+	(FruitFlavor)(0),                       // 131: unittest.FruitFlavor
+	(FruitType)(0),                         // 132: unittest.FruitType
+	(*timestamppb.Timestamp)(nil),          // 133: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),            // 134: google.protobuf.Duration
+	(*Target)(nil),                         // 135: unittest.Target
 }
 var file_tableau_protobuf_unittest_unittest_proto_depIdxs = []int32{
-	34,  // 0: unittest.SimpleIncellMap.item_map:type_name -> unittest.SimpleIncellMap.ItemMapEntry
-	35,  // 1: unittest.IncellMap.fruit_map:type_name -> unittest.IncellMap.FruitMapEntry
-	37,  // 2: unittest.IncellMap.flavor_map:type_name -> unittest.IncellMap.FlavorMapEntry
-	38,  // 3: unittest.IncellMap.item_map:type_name -> unittest.IncellMap.ItemMapEntry
-	127, // 4: unittest.IncellStructList.item_list:type_name -> unittest.Item
-	128, // 5: unittest.IncellList.flavor_list:type_name -> unittest.FruitFlavor
-	127, // 6: unittest.IncellList.item_list:type_name -> unittest.Item
-	40,  // 7: unittest.ItemConf.item_map:type_name -> unittest.ItemConf.ItemMapEntry
-	41,  // 8: unittest.MallConf.shop_map:type_name -> unittest.MallConf.ShopMapEntry
-	45,  // 9: unittest.ActivityConf.activity_map:type_name -> unittest.ActivityConf.ActivityMapEntry
-	52,  // 10: unittest.RewardConf.reward_map:type_name -> unittest.RewardConf.RewardMapEntry
-	55,  // 11: unittest.PatchMergeConf.time:type_name -> unittest.PatchMergeConf.Time
-	56,  // 12: unittest.PatchMergeConf.item_map:type_name -> unittest.PatchMergeConf.ItemMapEntry
-	57,  // 13: unittest.PatchMergeConf.replace_item_map:type_name -> unittest.PatchMergeConf.ReplaceItemMapEntry
-	58,  // 14: unittest.RecursivePatchConf.shop_map:type_name -> unittest.RecursivePatchConf.ShopMapEntry
+	35,  // 0: unittest.SimpleIncellMap.item_map:type_name -> unittest.SimpleIncellMap.ItemMapEntry
+	36,  // 1: unittest.IncellMap.fruit_map:type_name -> unittest.IncellMap.FruitMapEntry
+	38,  // 2: unittest.IncellMap.flavor_map:type_name -> unittest.IncellMap.FlavorMapEntry
+	39,  // 3: unittest.IncellMap.item_map:type_name -> unittest.IncellMap.ItemMapEntry
+	130, // 4: unittest.IncellStructList.item_list:type_name -> unittest.Item
+	131, // 5: unittest.IncellList.flavor_list:type_name -> unittest.FruitFlavor
+	130, // 6: unittest.IncellList.item_list:type_name -> unittest.Item
+	41,  // 7: unittest.ItemConf.item_map:type_name -> unittest.ItemConf.ItemMapEntry
+	42,  // 8: unittest.MallConf.shop_map:type_name -> unittest.MallConf.ShopMapEntry
+	46,  // 9: unittest.ActivityConf.activity_map:type_name -> unittest.ActivityConf.ActivityMapEntry
+	53,  // 10: unittest.RewardConf.reward_map:type_name -> unittest.RewardConf.RewardMapEntry
+	56,  // 11: unittest.PatchMergeConf.time:type_name -> unittest.PatchMergeConf.Time
+	57,  // 12: unittest.PatchMergeConf.item_map:type_name -> unittest.PatchMergeConf.ItemMapEntry
+	58,  // 13: unittest.PatchMergeConf.replace_item_map:type_name -> unittest.PatchMergeConf.ReplaceItemMapEntry
+	59,  // 14: unittest.RecursivePatchConf.shop_map:type_name -> unittest.RecursivePatchConf.ShopMapEntry
 	10,  // 15: unittest.JsonUtilTestData.normal_field:type_name -> unittest.PatchMergeConf
 	10,  // 16: unittest.JsonUtilTestData.list_field:type_name -> unittest.PatchMergeConf
-	67,  // 17: unittest.JsonUtilTestData.map_field:type_name -> unittest.JsonUtilTestData.MapFieldEntry
-	68,  // 18: unittest.UniqueFieldInVerticalStructList.item_list:type_name -> unittest.UniqueFieldInVerticalStructList.Item
-	69,  // 19: unittest.VerticalUniqueFieldStructMap.main_map:type_name -> unittest.VerticalUniqueFieldStructMap.MainMapEntry
-	74,  // 20: unittest.DocumentUniqueFieldStructList.item_list:type_name -> unittest.DocumentUniqueFieldStructList.Item
-	75,  // 21: unittest.DocumentUniqueFieldStructMap.chapter:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterEntry
-	77,  // 22: unittest.DocumentUniqueFieldStructMap.scalar_map:type_name -> unittest.DocumentUniqueFieldStructMap.ScalarMapEntry
-	78,  // 23: unittest.DocumentUniqueFieldStructMap.incell_map:type_name -> unittest.DocumentUniqueFieldStructMap.IncellMapEntry
-	79,  // 24: unittest.DocumentUniqueFieldStructMap.chapter_info:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfoEntry
-	89,  // 25: unittest.SequenceFieldInVerticalStructList.item_list:type_name -> unittest.SequenceFieldInVerticalStructList.Item
-	90,  // 26: unittest.SequenceKeyInVerticalKeyedList.item_list:type_name -> unittest.SequenceKeyInVerticalKeyedList.Item
-	93,  // 27: unittest.VerticalSequenceFieldStructMap.main_map:type_name -> unittest.VerticalSequenceFieldStructMap.MainMapEntry
-	97,  // 28: unittest.DocumentSequenceFieldStructList.item_list:type_name -> unittest.DocumentSequenceFieldStructList.Item
-	98,  // 29: unittest.Transpose.hero_map:type_name -> unittest.Transpose.HeroMapEntry
-	100, // 30: unittest.ValidateConf.prop_map:type_name -> unittest.ValidateConf.PropMapEntry
-	101, // 31: unittest.TaskConf.task_map:type_name -> unittest.TaskConf.TaskMapEntry
-	103, // 32: unittest.FieldPresentMap.player_map:type_name -> unittest.FieldPresentMap.PlayerMapEntry
-	108, // 33: unittest.ScatterNoneConf.zone_map:type_name -> unittest.ScatterNoneConf.ZoneMapEntry
-	110, // 34: unittest.ScatterReplaceConf.zone_map:type_name -> unittest.ScatterReplaceConf.ZoneMapEntry
-	112, // 35: unittest.ScatterMergeConf.zone_map:type_name -> unittest.ScatterMergeConf.ZoneMapEntry
-	114, // 36: unittest.MergerSingleConf.zone_map:type_name -> unittest.MergerSingleConf.ZoneMapEntry
-	116, // 37: unittest.MergerMultiConf.zone_map:type_name -> unittest.MergerMultiConf.ZoneMapEntry
-	118, // 38: unittest.VerticalAggregationMap.hero_map:type_name -> unittest.VerticalAggregationMap.HeroMapEntry
-	129, // 39: unittest.IncellKeyedList.type_list:type_name -> unittest.FruitType
-	127, // 40: unittest.IncellKeyedList.item_list:type_name -> unittest.Item
-	122, // 41: unittest.HorizontalAggregateMap.hero_map:type_name -> unittest.HorizontalAggregateMap.HeroMapEntry
-	125, // 42: unittest.HorizontalAggregateList.hero_map:type_name -> unittest.HorizontalAggregateList.HeroMapEntry
-	36,  // 43: unittest.IncellMap.FruitMapEntry.value:type_name -> unittest.IncellMap.Fruit
-	129, // 44: unittest.IncellMap.Fruit.key:type_name -> unittest.FruitType
-	128, // 45: unittest.IncellMap.FlavorMapEntry.value:type_name -> unittest.FruitFlavor
-	39,  // 46: unittest.IncellMap.ItemMapEntry.value:type_name -> unittest.IncellMap.Item
-	129, // 47: unittest.IncellMap.Item.key:type_name -> unittest.FruitType
-	128, // 48: unittest.IncellMap.Item.value:type_name -> unittest.FruitFlavor
-	127, // 49: unittest.ItemConf.ItemMapEntry.value:type_name -> unittest.Item
-	42,  // 50: unittest.MallConf.ShopMapEntry.value:type_name -> unittest.MallConf.Shop
-	43,  // 51: unittest.MallConf.Shop.goods_map:type_name -> unittest.MallConf.Shop.GoodsMapEntry
-	44,  // 52: unittest.MallConf.Shop.GoodsMapEntry.value:type_name -> unittest.MallConf.Shop.Goods
-	46,  // 53: unittest.ActivityConf.ActivityMapEntry.value:type_name -> unittest.ActivityConf.Activity
-	47,  // 54: unittest.ActivityConf.Activity.chapter_map:type_name -> unittest.ActivityConf.Activity.ChapterMapEntry
-	48,  // 55: unittest.ActivityConf.Activity.ChapterMapEntry.value:type_name -> unittest.ActivityConf.Activity.Chapter
-	49,  // 56: unittest.ActivityConf.Activity.Chapter.section_list:type_name -> unittest.ActivityConf.Activity.Chapter.Section
-	50,  // 57: unittest.ActivityConf.Activity.Chapter.Section.reward_map:type_name -> unittest.ActivityConf.Activity.Chapter.Section.RewardMapEntry
-	51,  // 58: unittest.ActivityConf.Activity.Chapter.Section.RewardMapEntry.value:type_name -> unittest.ActivityConf.Activity.Chapter.Section.Reward
-	53,  // 59: unittest.RewardConf.RewardMapEntry.value:type_name -> unittest.RewardConf.Reward
-	54,  // 60: unittest.RewardConf.Reward.item_map:type_name -> unittest.RewardConf.Reward.ItemMapEntry
-	127, // 61: unittest.RewardConf.Reward.ItemMapEntry.value:type_name -> unittest.Item
-	130, // 62: unittest.PatchMergeConf.Time.start:type_name -> google.protobuf.Timestamp
-	131, // 63: unittest.PatchMergeConf.Time.expiry:type_name -> google.protobuf.Duration
-	127, // 64: unittest.PatchMergeConf.ItemMapEntry.value:type_name -> unittest.Item
-	127, // 65: unittest.PatchMergeConf.ReplaceItemMapEntry.value:type_name -> unittest.Item
-	59,  // 66: unittest.RecursivePatchConf.ShopMapEntry.value:type_name -> unittest.RecursivePatchConf.Shop
-	60,  // 67: unittest.RecursivePatchConf.Shop.goods_map:type_name -> unittest.RecursivePatchConf.Shop.GoodsMapEntry
-	61,  // 68: unittest.RecursivePatchConf.Shop.GoodsMapEntry.value:type_name -> unittest.RecursivePatchConf.Shop.Goods
-	62,  // 69: unittest.RecursivePatchConf.Shop.Goods.currency_map:type_name -> unittest.RecursivePatchConf.Shop.Goods.CurrencyMapEntry
-	64,  // 70: unittest.RecursivePatchConf.Shop.Goods.award_list:type_name -> unittest.RecursivePatchConf.Shop.Goods.Award
-	63,  // 71: unittest.RecursivePatchConf.Shop.Goods.CurrencyMapEntry.value:type_name -> unittest.RecursivePatchConf.Shop.Goods.Currency
-	65,  // 72: unittest.RecursivePatchConf.Shop.Goods.Currency.value_list:type_name -> unittest.RecursivePatchConf.Shop.Goods.Currency.ValueListEntry
-	66,  // 73: unittest.RecursivePatchConf.Shop.Goods.Currency.message_list:type_name -> unittest.RecursivePatchConf.Shop.Goods.Currency.MessageListEntry
-	10,  // 74: unittest.JsonUtilTestData.MapFieldEntry.value:type_name -> unittest.PatchMergeConf
-	70,  // 75: unittest.VerticalUniqueFieldStructMap.MainMapEntry.value:type_name -> unittest.VerticalUniqueFieldStructMap.Main
-	71,  // 76: unittest.VerticalUniqueFieldStructMap.Main.main_kv_map:type_name -> unittest.VerticalUniqueFieldStructMap.Main.MainKvMapEntry
-	72,  // 77: unittest.VerticalUniqueFieldStructMap.Main.sub_map:type_name -> unittest.VerticalUniqueFieldStructMap.Main.SubMapEntry
-	73,  // 78: unittest.VerticalUniqueFieldStructMap.Main.SubMapEntry.value:type_name -> unittest.VerticalUniqueFieldStructMap.Main.Sub
-	76,  // 79: unittest.DocumentUniqueFieldStructMap.ChapterEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.Chapter
-	81,  // 80: unittest.DocumentUniqueFieldStructMap.Chapter.section:type_name -> unittest.DocumentUniqueFieldStructMap.Chapter.SectionEntry
-	80,  // 81: unittest.DocumentUniqueFieldStructMap.ChapterInfoEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo
-	83,  // 82: unittest.DocumentUniqueFieldStructMap.ChapterInfo.section:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.SectionEntry
-	82,  // 83: unittest.DocumentUniqueFieldStructMap.Chapter.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.Chapter.Section
-	84,  // 84: unittest.DocumentUniqueFieldStructMap.ChapterInfo.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section
-	85,  // 85: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.section:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.SectionEntry
-	86,  // 86: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section
-	87,  // 87: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.section:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.SectionEntry
-	88,  // 88: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.Section
-	91,  // 89: unittest.SequenceKeyInVerticalKeyedList.Item.prop_map:type_name -> unittest.SequenceKeyInVerticalKeyedList.Item.PropMapEntry
-	92,  // 90: unittest.SequenceKeyInVerticalKeyedList.Item.PropMapEntry.value:type_name -> unittest.SequenceKeyInVerticalKeyedList.Item.Prop
-	94,  // 91: unittest.VerticalSequenceFieldStructMap.MainMapEntry.value:type_name -> unittest.VerticalSequenceFieldStructMap.Main
-	95,  // 92: unittest.VerticalSequenceFieldStructMap.Main.sub_map:type_name -> unittest.VerticalSequenceFieldStructMap.Main.SubMapEntry
-	96,  // 93: unittest.VerticalSequenceFieldStructMap.Main.SubMapEntry.value:type_name -> unittest.VerticalSequenceFieldStructMap.Main.Sub
-	99,  // 94: unittest.Transpose.HeroMapEntry.value:type_name -> unittest.Transpose.Hero
-	102, // 95: unittest.TaskConf.TaskMapEntry.value:type_name -> unittest.TaskConf.Task
-	132, // 96: unittest.TaskConf.Task.target:type_name -> unittest.Target
-	104, // 97: unittest.FieldPresentMap.PlayerMapEntry.value:type_name -> unittest.FieldPresentMap.Player
-	105, // 98: unittest.FieldPresentMap.Player.weapon:type_name -> unittest.FieldPresentMap.Player.Weapon
-	106, // 99: unittest.FieldPresentMap.Player.info:type_name -> unittest.FieldPresentMap.Player.Info
-	107, // 100: unittest.FieldPresentMap.Player.attr_map:type_name -> unittest.FieldPresentMap.Player.AttrMapEntry
-	132, // 101: unittest.FieldPresentMap.Player.target:type_name -> unittest.Target
-	109, // 102: unittest.ScatterNoneConf.ZoneMapEntry.value:type_name -> unittest.ScatterNoneConf.Zone
-	111, // 103: unittest.ScatterReplaceConf.ZoneMapEntry.value:type_name -> unittest.ScatterReplaceConf.Zone
-	113, // 104: unittest.ScatterMergeConf.ZoneMapEntry.value:type_name -> unittest.ScatterMergeConf.Zone
-	115, // 105: unittest.MergerSingleConf.ZoneMapEntry.value:type_name -> unittest.MergerSingleConf.Zone
-	117, // 106: unittest.MergerMultiConf.ZoneMapEntry.value:type_name -> unittest.MergerMultiConf.Zone
-	119, // 107: unittest.VerticalAggregationMap.HeroMapEntry.value:type_name -> unittest.VerticalAggregationMap.Hero
-	120, // 108: unittest.VerticalAggregationMap.Hero.level_map:type_name -> unittest.VerticalAggregationMap.Hero.LevelMapEntry
-	121, // 109: unittest.VerticalAggregationMap.Hero.LevelMapEntry.value:type_name -> unittest.VerticalAggregationMap.Hero.Level
-	123, // 110: unittest.HorizontalAggregateMap.HeroMapEntry.value:type_name -> unittest.HorizontalAggregateMap.Hero
-	124, // 111: unittest.HorizontalAggregateMap.Hero.item_map:type_name -> unittest.HorizontalAggregateMap.Hero.ItemMapEntry
-	127, // 112: unittest.HorizontalAggregateMap.Hero.ItemMapEntry.value:type_name -> unittest.Item
-	126, // 113: unittest.HorizontalAggregateList.HeroMapEntry.value:type_name -> unittest.HorizontalAggregateList.Hero
-	127, // 114: unittest.HorizontalAggregateList.Hero.param_list:type_name -> unittest.Item
-	115, // [115:115] is the sub-list for method output_type
-	115, // [115:115] is the sub-list for method input_type
-	115, // [115:115] is the sub-list for extension type_name
-	115, // [115:115] is the sub-list for extension extendee
-	0,   // [0:115] is the sub-list for field type_name
+	68,  // 17: unittest.JsonUtilTestData.map_field:type_name -> unittest.JsonUtilTestData.MapFieldEntry
+	69,  // 18: unittest.UniqueFieldInVerticalStructList.item_list:type_name -> unittest.UniqueFieldInVerticalStructList.Item
+	70,  // 19: unittest.VerticalUniqueFieldStructMap.main_map:type_name -> unittest.VerticalUniqueFieldStructMap.MainMapEntry
+	75,  // 20: unittest.DocumentUniqueFieldStructList.item_list:type_name -> unittest.DocumentUniqueFieldStructList.Item
+	76,  // 21: unittest.DocumentUniqueFieldStructMap.chapter:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterEntry
+	78,  // 22: unittest.DocumentUniqueFieldStructMap.scalar_map:type_name -> unittest.DocumentUniqueFieldStructMap.ScalarMapEntry
+	79,  // 23: unittest.DocumentUniqueFieldStructMap.incell_map:type_name -> unittest.DocumentUniqueFieldStructMap.IncellMapEntry
+	80,  // 24: unittest.DocumentUniqueFieldStructMap.chapter_info:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfoEntry
+	90,  // 25: unittest.SequenceFieldInVerticalStructList.item_list:type_name -> unittest.SequenceFieldInVerticalStructList.Item
+	91,  // 26: unittest.SequenceKeyInVerticalKeyedList.item_list:type_name -> unittest.SequenceKeyInVerticalKeyedList.Item
+	94,  // 27: unittest.VerticalSequenceFieldStructMap.main_map:type_name -> unittest.VerticalSequenceFieldStructMap.MainMapEntry
+	98,  // 28: unittest.DocumentSequenceFieldStructList.item_list:type_name -> unittest.DocumentSequenceFieldStructList.Item
+	99,  // 29: unittest.Transpose.hero_map:type_name -> unittest.Transpose.HeroMapEntry
+	101, // 30: unittest.ValidateConf.prop_map:type_name -> unittest.ValidateConf.PropMapEntry
+	102, // 31: unittest.TaskConf.task_map:type_name -> unittest.TaskConf.TaskMapEntry
+	104, // 32: unittest.FieldPresentMap.player_map:type_name -> unittest.FieldPresentMap.PlayerMapEntry
+	109, // 33: unittest.ScatterNoneConf.zone_map:type_name -> unittest.ScatterNoneConf.ZoneMapEntry
+	111, // 34: unittest.ScatterReplaceConf.zone_map:type_name -> unittest.ScatterReplaceConf.ZoneMapEntry
+	113, // 35: unittest.ScatterMergeConf.zone_map:type_name -> unittest.ScatterMergeConf.ZoneMapEntry
+	115, // 36: unittest.MergerSingleConf.zone_map:type_name -> unittest.MergerSingleConf.ZoneMapEntry
+	117, // 37: unittest.MergerMultiConf.zone_map:type_name -> unittest.MergerMultiConf.ZoneMapEntry
+	119, // 38: unittest.VerticalAggregationMap.hero_map:type_name -> unittest.VerticalAggregationMap.HeroMapEntry
+	132, // 39: unittest.IncellKeyedList.type_list:type_name -> unittest.FruitType
+	130, // 40: unittest.IncellKeyedList.item_list:type_name -> unittest.Item
+	123, // 41: unittest.HorizontalAggregateMap.hero_map:type_name -> unittest.HorizontalAggregateMap.HeroMapEntry
+	126, // 42: unittest.HorizontalAggregateList.hero_map:type_name -> unittest.HorizontalAggregateList.HeroMapEntry
+	128, // 43: unittest.HorizontalListFieldConf.reward_map:type_name -> unittest.HorizontalListFieldConf.RewardMapEntry
+	37,  // 44: unittest.IncellMap.FruitMapEntry.value:type_name -> unittest.IncellMap.Fruit
+	132, // 45: unittest.IncellMap.Fruit.key:type_name -> unittest.FruitType
+	131, // 46: unittest.IncellMap.FlavorMapEntry.value:type_name -> unittest.FruitFlavor
+	40,  // 47: unittest.IncellMap.ItemMapEntry.value:type_name -> unittest.IncellMap.Item
+	132, // 48: unittest.IncellMap.Item.key:type_name -> unittest.FruitType
+	131, // 49: unittest.IncellMap.Item.value:type_name -> unittest.FruitFlavor
+	130, // 50: unittest.ItemConf.ItemMapEntry.value:type_name -> unittest.Item
+	43,  // 51: unittest.MallConf.ShopMapEntry.value:type_name -> unittest.MallConf.Shop
+	44,  // 52: unittest.MallConf.Shop.goods_map:type_name -> unittest.MallConf.Shop.GoodsMapEntry
+	45,  // 53: unittest.MallConf.Shop.GoodsMapEntry.value:type_name -> unittest.MallConf.Shop.Goods
+	47,  // 54: unittest.ActivityConf.ActivityMapEntry.value:type_name -> unittest.ActivityConf.Activity
+	48,  // 55: unittest.ActivityConf.Activity.chapter_map:type_name -> unittest.ActivityConf.Activity.ChapterMapEntry
+	49,  // 56: unittest.ActivityConf.Activity.ChapterMapEntry.value:type_name -> unittest.ActivityConf.Activity.Chapter
+	50,  // 57: unittest.ActivityConf.Activity.Chapter.section_list:type_name -> unittest.ActivityConf.Activity.Chapter.Section
+	51,  // 58: unittest.ActivityConf.Activity.Chapter.Section.reward_map:type_name -> unittest.ActivityConf.Activity.Chapter.Section.RewardMapEntry
+	52,  // 59: unittest.ActivityConf.Activity.Chapter.Section.RewardMapEntry.value:type_name -> unittest.ActivityConf.Activity.Chapter.Section.Reward
+	54,  // 60: unittest.RewardConf.RewardMapEntry.value:type_name -> unittest.RewardConf.Reward
+	55,  // 61: unittest.RewardConf.Reward.item_map:type_name -> unittest.RewardConf.Reward.ItemMapEntry
+	130, // 62: unittest.RewardConf.Reward.ItemMapEntry.value:type_name -> unittest.Item
+	133, // 63: unittest.PatchMergeConf.Time.start:type_name -> google.protobuf.Timestamp
+	134, // 64: unittest.PatchMergeConf.Time.expiry:type_name -> google.protobuf.Duration
+	130, // 65: unittest.PatchMergeConf.ItemMapEntry.value:type_name -> unittest.Item
+	130, // 66: unittest.PatchMergeConf.ReplaceItemMapEntry.value:type_name -> unittest.Item
+	60,  // 67: unittest.RecursivePatchConf.ShopMapEntry.value:type_name -> unittest.RecursivePatchConf.Shop
+	61,  // 68: unittest.RecursivePatchConf.Shop.goods_map:type_name -> unittest.RecursivePatchConf.Shop.GoodsMapEntry
+	62,  // 69: unittest.RecursivePatchConf.Shop.GoodsMapEntry.value:type_name -> unittest.RecursivePatchConf.Shop.Goods
+	63,  // 70: unittest.RecursivePatchConf.Shop.Goods.currency_map:type_name -> unittest.RecursivePatchConf.Shop.Goods.CurrencyMapEntry
+	65,  // 71: unittest.RecursivePatchConf.Shop.Goods.award_list:type_name -> unittest.RecursivePatchConf.Shop.Goods.Award
+	64,  // 72: unittest.RecursivePatchConf.Shop.Goods.CurrencyMapEntry.value:type_name -> unittest.RecursivePatchConf.Shop.Goods.Currency
+	66,  // 73: unittest.RecursivePatchConf.Shop.Goods.Currency.value_list:type_name -> unittest.RecursivePatchConf.Shop.Goods.Currency.ValueListEntry
+	67,  // 74: unittest.RecursivePatchConf.Shop.Goods.Currency.message_list:type_name -> unittest.RecursivePatchConf.Shop.Goods.Currency.MessageListEntry
+	10,  // 75: unittest.JsonUtilTestData.MapFieldEntry.value:type_name -> unittest.PatchMergeConf
+	71,  // 76: unittest.VerticalUniqueFieldStructMap.MainMapEntry.value:type_name -> unittest.VerticalUniqueFieldStructMap.Main
+	72,  // 77: unittest.VerticalUniqueFieldStructMap.Main.main_kv_map:type_name -> unittest.VerticalUniqueFieldStructMap.Main.MainKvMapEntry
+	73,  // 78: unittest.VerticalUniqueFieldStructMap.Main.sub_map:type_name -> unittest.VerticalUniqueFieldStructMap.Main.SubMapEntry
+	74,  // 79: unittest.VerticalUniqueFieldStructMap.Main.SubMapEntry.value:type_name -> unittest.VerticalUniqueFieldStructMap.Main.Sub
+	77,  // 80: unittest.DocumentUniqueFieldStructMap.ChapterEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.Chapter
+	82,  // 81: unittest.DocumentUniqueFieldStructMap.Chapter.section:type_name -> unittest.DocumentUniqueFieldStructMap.Chapter.SectionEntry
+	81,  // 82: unittest.DocumentUniqueFieldStructMap.ChapterInfoEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo
+	84,  // 83: unittest.DocumentUniqueFieldStructMap.ChapterInfo.section:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.SectionEntry
+	83,  // 84: unittest.DocumentUniqueFieldStructMap.Chapter.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.Chapter.Section
+	85,  // 85: unittest.DocumentUniqueFieldStructMap.ChapterInfo.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section
+	86,  // 86: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.section:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.SectionEntry
+	87,  // 87: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section
+	88,  // 88: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.section:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.SectionEntry
+	89,  // 89: unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.SectionEntry.value:type_name -> unittest.DocumentUniqueFieldStructMap.ChapterInfo.Section.Section.Section
+	92,  // 90: unittest.SequenceKeyInVerticalKeyedList.Item.prop_map:type_name -> unittest.SequenceKeyInVerticalKeyedList.Item.PropMapEntry
+	93,  // 91: unittest.SequenceKeyInVerticalKeyedList.Item.PropMapEntry.value:type_name -> unittest.SequenceKeyInVerticalKeyedList.Item.Prop
+	95,  // 92: unittest.VerticalSequenceFieldStructMap.MainMapEntry.value:type_name -> unittest.VerticalSequenceFieldStructMap.Main
+	96,  // 93: unittest.VerticalSequenceFieldStructMap.Main.sub_map:type_name -> unittest.VerticalSequenceFieldStructMap.Main.SubMapEntry
+	97,  // 94: unittest.VerticalSequenceFieldStructMap.Main.SubMapEntry.value:type_name -> unittest.VerticalSequenceFieldStructMap.Main.Sub
+	100, // 95: unittest.Transpose.HeroMapEntry.value:type_name -> unittest.Transpose.Hero
+	103, // 96: unittest.TaskConf.TaskMapEntry.value:type_name -> unittest.TaskConf.Task
+	135, // 97: unittest.TaskConf.Task.target:type_name -> unittest.Target
+	105, // 98: unittest.FieldPresentMap.PlayerMapEntry.value:type_name -> unittest.FieldPresentMap.Player
+	106, // 99: unittest.FieldPresentMap.Player.weapon:type_name -> unittest.FieldPresentMap.Player.Weapon
+	107, // 100: unittest.FieldPresentMap.Player.info:type_name -> unittest.FieldPresentMap.Player.Info
+	108, // 101: unittest.FieldPresentMap.Player.attr_map:type_name -> unittest.FieldPresentMap.Player.AttrMapEntry
+	135, // 102: unittest.FieldPresentMap.Player.target:type_name -> unittest.Target
+	110, // 103: unittest.ScatterNoneConf.ZoneMapEntry.value:type_name -> unittest.ScatterNoneConf.Zone
+	112, // 104: unittest.ScatterReplaceConf.ZoneMapEntry.value:type_name -> unittest.ScatterReplaceConf.Zone
+	114, // 105: unittest.ScatterMergeConf.ZoneMapEntry.value:type_name -> unittest.ScatterMergeConf.Zone
+	116, // 106: unittest.MergerSingleConf.ZoneMapEntry.value:type_name -> unittest.MergerSingleConf.Zone
+	118, // 107: unittest.MergerMultiConf.ZoneMapEntry.value:type_name -> unittest.MergerMultiConf.Zone
+	120, // 108: unittest.VerticalAggregationMap.HeroMapEntry.value:type_name -> unittest.VerticalAggregationMap.Hero
+	121, // 109: unittest.VerticalAggregationMap.Hero.level_map:type_name -> unittest.VerticalAggregationMap.Hero.LevelMapEntry
+	122, // 110: unittest.VerticalAggregationMap.Hero.LevelMapEntry.value:type_name -> unittest.VerticalAggregationMap.Hero.Level
+	124, // 111: unittest.HorizontalAggregateMap.HeroMapEntry.value:type_name -> unittest.HorizontalAggregateMap.Hero
+	125, // 112: unittest.HorizontalAggregateMap.Hero.item_map:type_name -> unittest.HorizontalAggregateMap.Hero.ItemMapEntry
+	130, // 113: unittest.HorizontalAggregateMap.Hero.ItemMapEntry.value:type_name -> unittest.Item
+	127, // 114: unittest.HorizontalAggregateList.HeroMapEntry.value:type_name -> unittest.HorizontalAggregateList.Hero
+	130, // 115: unittest.HorizontalAggregateList.Hero.param_list:type_name -> unittest.Item
+	129, // 116: unittest.HorizontalListFieldConf.RewardMapEntry.value:type_name -> unittest.HorizontalListFieldConf.Reward
+	130, // 117: unittest.HorizontalListFieldConf.Reward.item_list:type_name -> unittest.Item
+	118, // [118:118] is the sub-list for method output_type
+	118, // [118:118] is the sub-list for method input_type
+	118, // [118:118] is the sub-list for extension type_name
+	118, // [118:118] is the sub-list for extension extendee
+	0,   // [0:118] is the sub-list for field type_name
 }
 
 func init() { file_tableau_protobuf_unittest_unittest_proto_init() }
@@ -6266,7 +6396,19 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[36].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[34].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*HorizontalListFieldConf); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[37].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IncellMap_Fruit); i {
 			case 0:
 				return &v.state
@@ -6278,7 +6420,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[39].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[40].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*IncellMap_Item); i {
 			case 0:
 				return &v.state
@@ -6290,7 +6432,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[42].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[43].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MallConf_Shop); i {
 			case 0:
 				return &v.state
@@ -6302,7 +6444,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[44].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[45].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MallConf_Shop_Goods); i {
 			case 0:
 				return &v.state
@@ -6314,7 +6456,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[46].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[47].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ActivityConf_Activity); i {
 			case 0:
 				return &v.state
@@ -6326,7 +6468,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[48].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[49].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ActivityConf_Activity_Chapter); i {
 			case 0:
 				return &v.state
@@ -6338,7 +6480,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[49].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[50].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ActivityConf_Activity_Chapter_Section); i {
 			case 0:
 				return &v.state
@@ -6350,7 +6492,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[51].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[52].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ActivityConf_Activity_Chapter_Section_Reward); i {
 			case 0:
 				return &v.state
@@ -6362,7 +6504,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[53].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[54].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*RewardConf_Reward); i {
 			case 0:
 				return &v.state
@@ -6374,7 +6516,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[55].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[56].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*PatchMergeConf_Time); i {
 			case 0:
 				return &v.state
@@ -6386,7 +6528,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[59].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[60].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*RecursivePatchConf_Shop); i {
 			case 0:
 				return &v.state
@@ -6398,7 +6540,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[61].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[62].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*RecursivePatchConf_Shop_Goods); i {
 			case 0:
 				return &v.state
@@ -6410,7 +6552,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[63].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[64].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*RecursivePatchConf_Shop_Goods_Currency); i {
 			case 0:
 				return &v.state
@@ -6422,7 +6564,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[64].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[65].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*RecursivePatchConf_Shop_Goods_Award); i {
 			case 0:
 				return &v.state
@@ -6434,7 +6576,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[68].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[69].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*UniqueFieldInVerticalStructList_Item); i {
 			case 0:
 				return &v.state
@@ -6446,7 +6588,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[70].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[71].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*VerticalUniqueFieldStructMap_Main); i {
 			case 0:
 				return &v.state
@@ -6458,7 +6600,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[73].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[74].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*VerticalUniqueFieldStructMap_Main_Sub); i {
 			case 0:
 				return &v.state
@@ -6470,7 +6612,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[74].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[75].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructList_Item); i {
 			case 0:
 				return &v.state
@@ -6482,7 +6624,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[76].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[77].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructMap_Chapter); i {
 			case 0:
 				return &v.state
@@ -6494,7 +6636,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[80].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[81].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructMap_ChapterInfo); i {
 			case 0:
 				return &v.state
@@ -6506,7 +6648,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[82].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[83].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructMap_Chapter_Section); i {
 			case 0:
 				return &v.state
@@ -6518,7 +6660,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[84].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[85].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructMap_ChapterInfo_Section); i {
 			case 0:
 				return &v.state
@@ -6530,7 +6672,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[86].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[87].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section); i {
 			case 0:
 				return &v.state
@@ -6542,7 +6684,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[88].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[89].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentUniqueFieldStructMap_ChapterInfo_Section_Section_Section); i {
 			case 0:
 				return &v.state
@@ -6554,7 +6696,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[89].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[90].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SequenceFieldInVerticalStructList_Item); i {
 			case 0:
 				return &v.state
@@ -6566,7 +6708,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[90].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[91].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SequenceKeyInVerticalKeyedList_Item); i {
 			case 0:
 				return &v.state
@@ -6578,7 +6720,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[92].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[93].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*SequenceKeyInVerticalKeyedList_Item_Prop); i {
 			case 0:
 				return &v.state
@@ -6590,7 +6732,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[94].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[95].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*VerticalSequenceFieldStructMap_Main); i {
 			case 0:
 				return &v.state
@@ -6602,7 +6744,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[96].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[97].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*VerticalSequenceFieldStructMap_Main_Sub); i {
 			case 0:
 				return &v.state
@@ -6614,7 +6756,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[97].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[98].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*DocumentSequenceFieldStructList_Item); i {
 			case 0:
 				return &v.state
@@ -6626,7 +6768,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[99].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[100].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*Transpose_Hero); i {
 			case 0:
 				return &v.state
@@ -6638,7 +6780,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[102].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[103].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*TaskConf_Task); i {
 			case 0:
 				return &v.state
@@ -6650,7 +6792,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[104].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[105].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FieldPresentMap_Player); i {
 			case 0:
 				return &v.state
@@ -6662,7 +6804,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[105].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[106].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FieldPresentMap_Player_Weapon); i {
 			case 0:
 				return &v.state
@@ -6674,7 +6816,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[106].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[107].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FieldPresentMap_Player_Info); i {
 			case 0:
 				return &v.state
@@ -6686,7 +6828,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[109].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[110].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ScatterNoneConf_Zone); i {
 			case 0:
 				return &v.state
@@ -6698,7 +6840,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[111].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[112].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ScatterReplaceConf_Zone); i {
 			case 0:
 				return &v.state
@@ -6710,7 +6852,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[113].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[114].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ScatterMergeConf_Zone); i {
 			case 0:
 				return &v.state
@@ -6722,7 +6864,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[115].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[116].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MergerSingleConf_Zone); i {
 			case 0:
 				return &v.state
@@ -6734,7 +6876,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[117].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[118].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MergerMultiConf_Zone); i {
 			case 0:
 				return &v.state
@@ -6746,7 +6888,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[119].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[120].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*VerticalAggregationMap_Hero); i {
 			case 0:
 				return &v.state
@@ -6758,7 +6900,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[121].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[122].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*VerticalAggregationMap_Hero_Level); i {
 			case 0:
 				return &v.state
@@ -6770,7 +6912,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[123].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[124].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*HorizontalAggregateMap_Hero); i {
 			case 0:
 				return &v.state
@@ -6782,8 +6924,20 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 				return nil
 			}
 		}
-		file_tableau_protobuf_unittest_unittest_proto_msgTypes[126].Exporter = func(v interface{}, i int) interface{} {
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[127].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*HorizontalAggregateList_Hero); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_tableau_protobuf_unittest_unittest_proto_msgTypes[129].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*HorizontalListFieldConf_Reward); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -6802,7 +6956,7 @@ func file_tableau_protobuf_unittest_unittest_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_tableau_protobuf_unittest_unittest_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   127,
+			NumMessages:   130,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
## Summary

Add structured error code **E2029** for "no cell found with digit suffix for horizontal list/map field", replacing two generic `xerrors.Newf` messages that had no code or cell position.

```
error[E2029]: no cell found with digit suffix for horizontal map field "Item"
  DataCellPos: [B...C]2
  DataCell: [100...200]
  Help: add columns with digit suffix (e.g., "Item1", "Item2") ... or set prop "optional:true"
```

Also tightens `CLAUDE.md` (removes redundant prose, fixes a stale golangci-lint version pin) — no actionable guidance removed.

## Changes

- **ecode configs (`en.yaml` + `zh.yaml`)**: add `E2029` with `FieldName`/`FieldType` fields (`FieldType` = `"list"`/`"map"`).
- **`ecode_generated.go`**: regenerated — `ErrE2029` + `func E2029(fieldName, fieldType)`.
- **`table_parser.go`**: wire `parseHorizontalMapField`/`parseHorizontalListField` to `xerrors.E2029` wrapped with `r.CellDebugKV(newPrefix)` for Excel position details.
- **`unittest.proto` + `unittest.pb.go`**: add `HorizontalListFieldConf` (vertical map keyed by ID → horizontal list of predefined `unittest.Item`) for the list-path test.
- **`table_parser_test.go`**: tests covering both paths — assert `ErrE2029`, position details, and rendered summary.
- **`CLAUDE.md`**: tighten prose, drop redundancy, fix stale golangci-lint version.

## Verification

`go build` · `go vet` · `go test ./...` · `./test/functest/run.sh` · `buf generate` (idempotent) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
