### PR TITLE
fix(confgen): dedup refer load errors and locate them to referred target

### DIFF
--- a/internal/confgen/confgen.go
+++ b/internal/confgen/confgen.go
@@ -10,6 +10,7 @@ import (
 
 	"buf.build/go/protovalidate"
 	"github.com/tableauio/tableau/format"
+	"github.com/tableauio/tableau/internal/confgen/fieldprop"
 	"github.com/tableauio/tableau/internal/importer"
 	"github.com/tableauio/tableau/internal/importer/metasheet"
 	"github.com/tableauio/tableau/internal/strcase"
@@ -95,6 +96,8 @@ func (gen *Generator) Generate(bookSpecifiers ...string) (err error) {
 }
 
 func (gen *Generator) GenAll() error {
+	// Drop refer value spaces from a previous run in this process.
+	fieldprop.ResetReferredCache()
 	prFiles, err := loadProtoRegistryFiles(gen.ProtoPackage, gen.InputOpt.ProtoPaths, gen.InputOpt.ProtoFiles, gen.InputOpt.ExcludedProtoFiles...)
 	if err != nil {
 		return err
@@ -121,6 +124,8 @@ func (gen *Generator) GenAll() error {
 //   - only workbook: excel/Item.xlsx
 //   - with worksheet: excel/Item.xlsx#Item (To be implemented)
 func (gen *Generator) GenWorkbook(bookSpecifiers ...string) error {
+	// Drop refer value spaces from a previous run in this process.
+	fieldprop.ResetReferredCache()
 	prFiles, err := loadProtoRegistryFiles(gen.ProtoPackage, gen.InputOpt.ProtoPaths, gen.InputOpt.ProtoFiles, gen.InputOpt.ExcludedProtoFiles...)
 	if err != nil {
 		return err

--- a/internal/confgen/confgen.go
+++ b/internal/confgen/confgen.go
@@ -37,8 +37,9 @@ type Generator struct {
 	OutputOpt     *options.ConfOutputOption // output settings.
 	ErrorLimitOpt *options.ErrorLimitOption // error collection limits.
 
-	validator protovalidate.Validator // validator with extension type resolver for custom predefined rules.
-	collector *xerrors.Collector      // concurrent error collector shared across the generator.
+	validator     protovalidate.Validator  // validator with extension type resolver for custom predefined rules.
+	collector     *xerrors.Collector       // concurrent error collector shared across the generator.
+	referredCache *fieldprop.ReferredCache // refer value-space cache for this generate run
 
 	// Performance stats
 	PerfStats sync.Map
@@ -78,6 +79,7 @@ func NewGeneratorWithOptions(protoPackage, indir, outdir string, opts *options.O
 		ErrorLimitOpt: errorLimit,
 		ctx:           ctx,
 		collector:     xerrors.NewCollector(errorLimit.MaxErrors),
+		referredCache: fieldprop.NewReferredCache(),
 		PerfStats:     sync.Map{},
 	}
 	return g
@@ -96,8 +98,6 @@ func (gen *Generator) Generate(bookSpecifiers ...string) (err error) {
 }
 
 func (gen *Generator) GenAll() error {
-	// Drop refer value spaces from a previous run in this process.
-	fieldprop.ResetReferredCache()
 	prFiles, err := loadProtoRegistryFiles(gen.ProtoPackage, gen.InputOpt.ProtoPaths, gen.InputOpt.ProtoFiles, gen.InputOpt.ExcludedProtoFiles...)
 	if err != nil {
 		return err
@@ -124,8 +124,6 @@ func (gen *Generator) GenAll() error {
 //   - only workbook: excel/Item.xlsx
 //   - with worksheet: excel/Item.xlsx#Item (To be implemented)
 func (gen *Generator) GenWorkbook(bookSpecifiers ...string) error {
-	// Drop refer value spaces from a previous run in this process.
-	fieldprop.ResetReferredCache()
 	prFiles, err := loadProtoRegistryFiles(gen.ProtoPackage, gen.InputOpt.ProtoPaths, gen.InputOpt.ProtoFiles, gen.InputOpt.ExcludedProtoFiles...)
 	if err != nil {
 		return err
@@ -217,6 +215,7 @@ func (gen *Generator) convert(prFiles *protoregistry.Files, fd protoreflect.File
 				BookFormat:     workbookFormat,
 				DryRun:         gen.OutputOpt.DryRun,
 				ErrorLimit:     gen.ErrorLimitOpt,
+				ReferredCache:  gen.referredCache,
 			},
 		})
 		// NOTE: one sheet may be generated to multiple messages (e.g.: full version and lite version) in the same workbook.

--- a/internal/confgen/fieldprop/refer.go
+++ b/internal/confgen/fieldprop/refer.go
@@ -27,34 +27,31 @@ func init() {
 	// - Item(ItemConf).ID
 	// - Item-(Award)(ItemConf).ID
 	referRegexp = regexp.MustCompile(`(?P<Sheet>.+?)` + `(\((?P<Alias>\w+)\))?` + `\.` + `(?P<Column>\w+)`)
-
-	referredCache = NewReferredCache()
 }
 
-var referredCache *ReferredCache
-
+// ReferredCache holds refer target column value spaces for one generate/load run.
 type ReferredCache struct {
-	sync.RWMutex
-	references map[string]*ValueSpace // message name -> sheet column value space
+	mu         sync.RWMutex
+	references map[string]*valueSpace // message name -> sheet column value space
 	// failed records refer expressions whose value space failed to load.
 	// The first failure is still surfaced to the caller; subsequent
-	// ExistsValue calls for the same refer short-circuit to "present" so
+	// InReferredSpace calls for the same refer short-circuit to "present" so
 	// one broken refer target does not spam N duplicate errors (one per
 	// row of the referring sheet).
 	failed map[string]struct{}
 }
 
-type ValueSpace struct {
+type valueSpace struct {
 	*hashset.Set
 }
 
-func NewValueSpace() *ValueSpace {
-	return &ValueSpace{
+func newValueSpace() *valueSpace {
+	return &valueSpace{
 		Set: hashset.New(),
 	}
 }
 
-func (v *ValueSpace) AddFromTable(header *tableparser.Header, table book.Tabler, columnName, bookName, sheetName string) error {
+func (v *valueSpace) addFromTable(header *tableparser.Header, table book.Tabler, columnName, bookName, sheetName string) error {
 	err := tableparser.RangeDataRows(table, header, func(r *book.Row) error {
 		cell, err := r.Cell(columnName, false)
 		if err != nil {
@@ -77,95 +74,87 @@ func (v *ValueSpace) AddFromTable(header *tableparser.Header, table book.Tabler,
 
 func NewReferredCache() *ReferredCache {
 	return &ReferredCache{
-		references: make(map[string]*ValueSpace),
+		references: make(map[string]*valueSpace),
 		failed:     make(map[string]struct{}),
 	}
 }
 
-// Reset clears both successful value spaces and remembered load failures.
-func (r *ReferredCache) Reset() {
-	r.Lock()
-	defer r.Unlock()
-	r.references = make(map[string]*ValueSpace)
+func (r *ReferredCache) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.references = make(map[string]*valueSpace)
 	r.failed = make(map[string]struct{})
 }
 
-// ResetReferredCache clears the process-level refer value-space cache.
-// Confgen calls this at the start of each GenAll/GenWorkbook so a previous
-// run's failures or stale workbook snapshot cannot leak into the next run.
-func ResetReferredCache() {
-	referredCache.Reset()
-}
-
-func (r *ReferredCache) Exists(refer string) bool {
-	r.RLock()
-	defer r.RUnlock()
+func (r *ReferredCache) exists(refer string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	_, ok := r.references[refer]
 	return ok
 }
 
-type loadValueSpaceFunc = func(refer string) (*ValueSpace, error)
+type loadValueSpaceFunc = func(refer string) (*valueSpace, error)
 
-func (r *ReferredCache) ExistsValue(refer string, value string, loadFunc loadValueSpaceFunc) (bool, error) {
-	r.RLock()
-	valueSpace, ok := r.references[refer]
+func (r *ReferredCache) existsValue(refer string, value string, loadFunc loadValueSpaceFunc) (bool, error) {
+	r.mu.RLock()
+	space, ok := r.references[refer]
 	_, isFailed := r.failed[refer]
-	r.RUnlock()
+	r.mu.RUnlock()
 	if isFailed {
 		// A prior load surfaced the real error already; silence follow-ups
 		// on the same refer target.
 		return true, nil
 	}
 	if ok {
-		return valueSpace.Contains(value), nil
+		return space.Contains(value), nil
 	}
 
 	// load value space once
-	r.Lock()
-	defer r.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if _, isFailed = r.failed[refer]; isFailed {
 		return true, nil
 	}
-	valueSpace, ok = r.references[refer]
+	space, ok = r.references[refer]
 	if ok {
-		return valueSpace.Contains(value), nil
+		return space.Contains(value), nil
 	}
-	valueSpace, err := loadFunc(refer)
+	space, err := loadFunc(refer)
 	if err != nil {
 		// Remember the failure so future callers short-circuit instead of
 		// re-triggering loadFunc (and re-emitting the same error).
 		r.failed[refer] = struct{}{}
 		return false, err
 	}
-	r.references[refer] = valueSpace
-	return valueSpace.Contains(value), nil
+	r.references[refer] = space
+	return space.Contains(value), nil
 }
 
-func (r *ReferredCache) Put(refer string, valueSpace *ValueSpace) {
-	r.Lock()
-	defer r.Unlock()
-	r.references[refer] = valueSpace
+func (r *ReferredCache) put(refer string, space *valueSpace) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.references[refer] = space
 }
 
-type ReferDesc struct {
+type referDesc struct {
 	Sheet  string // sheet name in workbook.
 	Alias  string // sheet alias: if set, used as protobuf message name.
 	Column string // sheet column name in name row.
 }
 
-func (r *ReferDesc) GetMessageName() string {
-	if r.Alias != "" {
-		return r.Alias
+func (d *referDesc) getMessageName() string {
+	if d.Alias != "" {
+		return d.Alias
 	}
-	return r.Sheet
+	return d.Sheet
 }
 
-func parseRefer(text string) (*ReferDesc, error) {
+func parseRefer(text string) (*referDesc, error) {
 	match := referRegexp.FindStringSubmatch(text)
 	if match == nil {
 		return nil, xerrors.Newf("invalid refer pattern: %s", text)
 	}
-	desc := &ReferDesc{}
+	desc := &referDesc{}
 	for i, name := range referRegexp.SubexpNames() {
 		value := strings.TrimSpace(match[i])
 		switch name {
@@ -180,6 +169,7 @@ func parseRefer(text string) (*ReferDesc, error) {
 	return desc, nil
 }
 
+// Input is the workbook lookup context for InReferredSpace.
 type Input struct {
 	ProtoPackage   string
 	InputDir       string
@@ -188,15 +178,15 @@ type Input struct {
 	Present        bool // field presence
 }
 
-func loadValueSpace(ctx context.Context, refer string, input *Input) (*ValueSpace, error) {
+func loadValueSpace(ctx context.Context, refer string, input *Input) (*valueSpace, error) {
 	referInfo, err := parseRefer(refer)
 	if err != nil {
 		return nil, err
 	}
-	fullName := protoreflect.FullName(input.ProtoPackage + "." + referInfo.GetMessageName())
+	fullName := protoreflect.FullName(input.ProtoPackage + "." + referInfo.getMessageName())
 	desc, err := input.PRFiles.FindDescriptorByName(fullName)
 	if err != nil {
-		return nil, xerrors.E2001(refer, referInfo.GetMessageName())
+		return nil, xerrors.E2001(refer, referInfo.getMessageName())
 	}
 
 	// get workbook name and worksheet name
@@ -226,7 +216,7 @@ func loadValueSpace(ctx context.Context, refer string, input *Input) (*ValueSpac
 	impInfos = append(impInfos, importer.ImporterInfo{Importer: primaryImporter})
 	header := tableparser.NewHeader(sheetOpts, bookOpts, nil)
 	// new empty referred value space set
-	valueSpace := NewValueSpace()
+	space := newValueSpace()
 	for _, impInfo := range impInfos {
 		specifiedSheetName := sheetName
 		if impInfo.SpecifiedSheetName != "" {
@@ -240,22 +230,22 @@ func loadValueSpace(ctx context.Context, refer string, input *Input) (*ValueSpac
 		}
 
 		if sheetOpts.Transpose {
-			err = valueSpace.AddFromTable(header, sheet.Table.Transpose(), referInfo.Column, bookName, sheetName)
+			err = space.addFromTable(header, sheet.Table.Transpose(), referInfo.Column, bookName, sheetName)
 		} else {
-			err = valueSpace.AddFromTable(header, sheet.Table, referInfo.Column, bookName, sheetName)
+			err = space.addFromTable(header, sheet.Table, referInfo.Column, bookName, sheetName)
 		}
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return valueSpace, nil
+	return space, nil
 }
 
 // InReferredSpace checks whether the cell data is at least in one of the other sheets'
 // column value space (aka message's field value space). prop.Refer is comma separated,
 // e.g.: "SheetName(SheetAlias).ColumnName[,SheetName(SheetAlias).ColumnName]..."
-func InReferredSpace(ctx context.Context, prop *tableaupb.FieldProp, cellData string, input *Input) (bool, error) {
+func (r *ReferredCache) InReferredSpace(ctx context.Context, prop *tableaupb.FieldProp, cellData string, input *Input) (bool, error) {
 	if prop == nil || strings.TrimSpace(prop.Refer) == "" {
 		return true, nil
 	}
@@ -263,14 +253,17 @@ func InReferredSpace(ctx context.Context, prop *tableaupb.FieldProp, cellData st
 	if !input.Present && !prop.Present {
 		return true, nil
 	}
+	if r == nil {
+		r = NewReferredCache()
+	}
 
-	loadFunc := func(refer string) (*ValueSpace, error) {
+	loadFunc := func(refer string) (*valueSpace, error) {
 		return loadValueSpace(ctx, refer, input)
 	}
 
 	// NOTE: prop.Refer is comma separated, e.g.: "SheetName(SheetAlias).ColumnName[,SheetName(SheetAlias).ColumnName]..."
 	for _, refer := range strings.Split(prop.Refer, ",") {
-		ok, err := referredCache.ExistsValue(refer, cellData, loadFunc)
+		ok, err := r.existsValue(refer, cellData, loadFunc)
 		if err != nil {
 			return false, err
 		}

--- a/internal/confgen/fieldprop/refer.go
+++ b/internal/confgen/fieldprop/refer.go
@@ -36,6 +36,12 @@ var referredCache *ReferredCache
 type ReferredCache struct {
 	sync.RWMutex
 	references map[string]*ValueSpace // message name -> sheet column value space
+	// failed records refer expressions whose value space failed to load.
+	// The first failure is still surfaced to the caller; subsequent
+	// ExistsValue calls for the same refer short-circuit to "present" so
+	// one broken refer target does not spam N duplicate errors (one per
+	// row of the referring sheet).
+	failed map[string]struct{}
 }
 
 type ValueSpace struct {
@@ -49,7 +55,7 @@ func NewValueSpace() *ValueSpace {
 }
 
 func (v *ValueSpace) AddFromTable(header *tableparser.Header, table book.Tabler, columnName, bookName, sheetName string) error {
-	return tableparser.RangeDataRows(table, header, func(r *book.Row) error {
+	err := tableparser.RangeDataRows(table, header, func(r *book.Row) error {
 		cell, err := r.Cell(columnName, false)
 		if err != nil {
 			return xerrors.E2015(columnName, bookName, sheetName)
@@ -57,11 +63,22 @@ func (v *ValueSpace) AddFromTable(header *tableparser.Header, table book.Tabler,
 		v.Add(cell.Data)
 		return nil
 	})
+	if err != nil {
+		// Tag with the referred target so outer confgen wrappers (which set
+		// BookName/SheetName to the source sheet under generation) don't
+		// obscure where the offending row actually lives.
+		return xerrors.WrapKV(err,
+			xerrors.KeyReferBookName, bookName,
+			xerrors.KeyReferSheetName, sheetName,
+		)
+	}
+	return nil
 }
 
 func NewReferredCache() *ReferredCache {
 	return &ReferredCache{
 		references: make(map[string]*ValueSpace),
+		failed:     make(map[string]struct{}),
 	}
 }
 
@@ -77,7 +94,13 @@ type loadValueSpaceFunc = func(refer string) (*ValueSpace, error)
 func (r *ReferredCache) ExistsValue(refer string, value string, loadFunc loadValueSpaceFunc) (bool, error) {
 	r.RLock()
 	valueSpace, ok := r.references[refer]
+	_, isFailed := r.failed[refer]
 	r.RUnlock()
+	if isFailed {
+		// A prior load surfaced the real error already; silence follow-ups
+		// on the same refer target.
+		return true, nil
+	}
 	if ok {
 		return valueSpace.Contains(value), nil
 	}
@@ -85,12 +108,18 @@ func (r *ReferredCache) ExistsValue(refer string, value string, loadFunc loadVal
 	// load value space once
 	r.Lock()
 	defer r.Unlock()
+	if _, isFailed = r.failed[refer]; isFailed {
+		return true, nil
+	}
 	valueSpace, ok = r.references[refer]
 	if ok {
 		return valueSpace.Contains(value), nil
 	}
 	valueSpace, err := loadFunc(refer)
 	if err != nil {
+		// Remember the failure so future callers short-circuit instead of
+		// re-triggering loadFunc (and re-emitting the same error).
+		r.failed[refer] = struct{}{}
 		return false, err
 	}
 	r.references[refer] = valueSpace

--- a/internal/confgen/fieldprop/refer.go
+++ b/internal/confgen/fieldprop/refer.go
@@ -82,6 +82,21 @@ func NewReferredCache() *ReferredCache {
 	}
 }
 
+// Reset clears both successful value spaces and remembered load failures.
+func (r *ReferredCache) Reset() {
+	r.Lock()
+	defer r.Unlock()
+	r.references = make(map[string]*ValueSpace)
+	r.failed = make(map[string]struct{})
+}
+
+// ResetReferredCache clears the process-level refer value-space cache.
+// Confgen calls this at the start of each GenAll/GenWorkbook so a previous
+// run's failures or stale workbook snapshot cannot leak into the next run.
+func ResetReferredCache() {
+	referredCache.Reset()
+}
+
 func (r *ReferredCache) Exists(refer string) bool {
 	r.RLock()
 	defer r.RUnlock()

--- a/internal/confgen/fieldprop/refer_test.go
+++ b/internal/confgen/fieldprop/refer_test.go
@@ -23,7 +23,7 @@ func Test_parseRefer(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    *ReferDesc
+		want    *referDesc
 		wantErr bool
 	}{
 		{
@@ -31,21 +31,21 @@ func Test_parseRefer(t *testing.T) {
 			args: args{
 				text: "Item.ID",
 			},
-			want: &ReferDesc{"Item", "", "ID"},
+			want: &referDesc{"Item", "", "ID"},
 		},
 		{
 			name: "with alias",
 			args: args{
 				text: "Item(ItemConf).ID",
 			},
-			want: &ReferDesc{"Item", "ItemConf", "ID"},
+			want: &referDesc{"Item", "ItemConf", "ID"},
 		},
 		{
 			name: "special-sheet-name-and-with-alias",
 			args: args{
 				text: "Item-(Award)(ItemConf).ID",
 			},
-			want: &ReferDesc{"Item-(Award)", "ItemConf", "ID"},
+			want: &referDesc{"Item-(Award)", "ItemConf", "ID"},
 		},
 	}
 	for _, tt := range tests {
@@ -205,9 +205,10 @@ func TestInReferredSpace(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	cache := NewReferredCache()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := InReferredSpace(context.Background(), tt.args.prop, tt.args.cellData, tt.args.input)
+			got, err := cache.InReferredSpace(context.Background(), tt.args.prop, tt.args.cellData, tt.args.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("InReferredSpace() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -220,9 +221,7 @@ func TestInReferredSpace(t *testing.T) {
 }
 
 func TestInReferredSpace_loadFailureDedup(t *testing.T) {
-	ResetReferredCache()
-	t.Cleanup(ResetReferredCache)
-
+	cache := NewReferredCache()
 	input := &Input{
 		ProtoPackage:   "unittest",
 		InputDir:       "../../../testdata",
@@ -232,7 +231,7 @@ func TestInReferredSpace_loadFailureDedup(t *testing.T) {
 	}
 	prop := &tableaupb.FieldProp{Refer: "DoesNotExistConf.ID"}
 
-	ok, err := InReferredSpace(context.Background(), prop, "1", input)
+	ok, err := cache.InReferredSpace(context.Background(), prop, "1", input)
 	if err == nil {
 		t.Fatal("first InReferredSpace() error = nil, want load error")
 	}
@@ -240,7 +239,7 @@ func TestInReferredSpace_loadFailureDedup(t *testing.T) {
 		t.Errorf("first InReferredSpace() = true, want false")
 	}
 
-	ok, err = InReferredSpace(context.Background(), prop, "2", input)
+	ok, err = cache.InReferredSpace(context.Background(), prop, "2", input)
 	if err != nil {
 		t.Fatalf("second InReferredSpace() error = %v, want nil (deduped)", err)
 	}
@@ -269,8 +268,8 @@ func TestValueSpace_AddFromTable(t *testing.T) {
 			{"1", "apple"},
 			{"2", "orange"},
 		})
-		vs := NewValueSpace()
-		if err := vs.AddFromTable(header, table, "ID", "Item.xlsx", "Item"); err != nil {
+		vs := newValueSpace()
+		if err := vs.addFromTable(header, table, "ID", "Item.xlsx", "Item"); err != nil {
 			t.Fatalf("AddFromTable() error = %v", err)
 		}
 		if !vs.Contains("1") || !vs.Contains("2") {
@@ -285,7 +284,7 @@ func TestValueSpace_AddFromTable(t *testing.T) {
 			{"id", "name"},
 			{"1", "apple"},
 		})
-		err := NewValueSpace().AddFromTable(header, table, "Missing", "AssistSkill.xlsx", "AssistSkill")
+		err := newValueSpace().addFromTable(header, table, "Missing", "AssistSkill.xlsx", "AssistSkill")
 		if err == nil {
 			t.Fatal("AddFromTable() error = nil, want error")
 		}
@@ -305,7 +304,7 @@ func TestValueSpace_AddFromTable(t *testing.T) {
 			{"id", "name", "ignore"},
 			{"1", "apple", "not-a-bool"},
 		})
-		err := NewValueSpace().AddFromTable(header, table, "ID", "AssistSkill.xlsx", "AssistSkill")
+		err := newValueSpace().addFromTable(header, table, "ID", "AssistSkill.xlsx", "AssistSkill")
 		if err == nil {
 			t.Fatal("AddFromTable() error = nil, want error")
 		}
@@ -322,12 +321,12 @@ func TestValueSpace_AddFromTable(t *testing.T) {
 func TestReferredCache_ExistsValue_loadFailureDedup(t *testing.T) {
 	cache := NewReferredCache()
 	var loads int32
-	loadFunc := func(refer string) (*ValueSpace, error) {
+	loadFunc := func(refer string) (*valueSpace, error) {
 		atomic.AddInt32(&loads, 1)
 		return nil, errors.New("load failed")
 	}
 
-	ok, err := cache.ExistsValue("Broken.ID", "1", loadFunc)
+	ok, err := cache.existsValue("Broken.ID", "1", loadFunc)
 	if err == nil {
 		t.Fatal("first ExistsValue() error = nil, want error")
 	}
@@ -335,7 +334,7 @@ func TestReferredCache_ExistsValue_loadFailureDedup(t *testing.T) {
 		t.Errorf("first ExistsValue() = true, want false")
 	}
 
-	ok, err = cache.ExistsValue("Broken.ID", "2", loadFunc)
+	ok, err = cache.existsValue("Broken.ID", "2", loadFunc)
 	if err != nil {
 		t.Fatalf("second ExistsValue() error = %v, want nil", err)
 	}
@@ -353,7 +352,7 @@ func TestReferredCache_ExistsValue_loadFailureDedupConcurrent(t *testing.T) {
 	cache := NewReferredCache()
 	var loads int32
 	start := make(chan struct{})
-	loadFunc := func(refer string) (*ValueSpace, error) {
+	loadFunc := func(refer string) (*valueSpace, error) {
 		atomic.AddInt32(&loads, 1)
 		return nil, errors.New("load failed")
 	}
@@ -370,7 +369,7 @@ func TestReferredCache_ExistsValue_loadFailureDedupConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
-			ok, err := cache.ExistsValue("BrokenConcurrent.ID", "v", loadFunc)
+			ok, err := cache.existsValue("BrokenConcurrent.ID", "v", loadFunc)
 			results[i] = result{ok, err}
 		}(i)
 	}
@@ -404,12 +403,12 @@ func TestReferredCache_ExistsValue_loadFailureDedupConcurrent(t *testing.T) {
 
 func TestReferredCache_Reset(t *testing.T) {
 	cache := NewReferredCache()
-	vs := NewValueSpace()
+	vs := newValueSpace()
 	vs.Add("1")
-	cache.Put("OK.ID", vs)
+	cache.put("OK.ID", vs)
 
 	var loads int32
-	_, err := cache.ExistsValue("Broken.ID", "1", func(string) (*ValueSpace, error) {
+	_, err := cache.existsValue("Broken.ID", "1", func(string) (*valueSpace, error) {
 		atomic.AddInt32(&loads, 1)
 		return nil, errors.New("load failed")
 	})
@@ -417,13 +416,13 @@ func TestReferredCache_Reset(t *testing.T) {
 		t.Fatal("ExistsValue() error = nil, want error")
 	}
 
-	cache.Reset()
+	cache.reset()
 
-	if cache.Exists("OK.ID") {
+	if cache.exists("OK.ID") {
 		t.Error("Exists(OK.ID) = true after Reset, want false")
 	}
 
-	_, err = cache.ExistsValue("Broken.ID", "1", func(string) (*ValueSpace, error) {
+	_, err = cache.existsValue("Broken.ID", "1", func(string) (*valueSpace, error) {
 		atomic.AddInt32(&loads, 1)
 		return nil, errors.New("load failed")
 	})
@@ -435,10 +434,21 @@ func TestReferredCache_Reset(t *testing.T) {
 	}
 }
 
-func TestResetReferredCache(t *testing.T) {
-	ResetReferredCache()
-	t.Cleanup(ResetReferredCache)
+func TestInReferredSpace_nilReceiver(t *testing.T) {
+	var cache *ReferredCache
+	input := &Input{
+		ProtoPackage: "unittest",
+		InputDir:     "../../../testdata",
+		PRFiles:      protoregistry.GlobalFiles,
+		Present:      true,
+	}
+	_, err := cache.InReferredSpace(context.Background(), &tableaupb.FieldProp{Refer: "DoesNotExistConf.ID"}, "1", input)
+	if err == nil {
+		t.Fatal("nil receiver InReferredSpace() error = nil, want load error")
+	}
+}
 
+func TestInReferredSpace_cacheIsolation(t *testing.T) {
 	prop := &tableaupb.FieldProp{Refer: "DoesNotExistConf.ID"}
 	input := &Input{
 		ProtoPackage: "unittest",
@@ -446,13 +456,10 @@ func TestResetReferredCache(t *testing.T) {
 		PRFiles:      protoregistry.GlobalFiles,
 		Present:      true,
 	}
-	if _, err := InReferredSpace(context.Background(), prop, "1", input); err == nil {
-		t.Fatal("first InReferredSpace() error = nil, want load error")
+	if _, err := NewReferredCache().InReferredSpace(context.Background(), prop, "1", input); err == nil {
+		t.Fatal("first cache InReferredSpace() error = nil, want load error")
 	}
-
-	ResetReferredCache()
-
-	if _, err := InReferredSpace(context.Background(), prop, "1", input); err == nil {
-		t.Fatal("InReferredSpace() after ResetReferredCache error = nil, want load to be retried")
+	if _, err := NewReferredCache().InReferredSpace(context.Background(), prop, "1", input); err == nil {
+		t.Fatal("isolated cache should retry load, want error")
 	}
 }

--- a/internal/confgen/fieldprop/refer_test.go
+++ b/internal/confgen/fieldprop/refer_test.go
@@ -2,9 +2,15 @@ package fieldprop
 
 import (
 	"context"
+	"errors"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/tableauio/tableau/internal/importer/book"
+	"github.com/tableauio/tableau/internal/importer/book/tableparser"
+	"github.com/tableauio/tableau/internal/x/xerrors"
 	"github.com/tableauio/tableau/proto/tableaupb"
 	_ "github.com/tableauio/tableau/proto/tableaupb/unittestpb"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -210,5 +216,243 @@ func TestInReferredSpace(t *testing.T) {
 				t.Errorf("InReferredSpace() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestInReferredSpace_loadFailureDedup(t *testing.T) {
+	ResetReferredCache()
+	t.Cleanup(ResetReferredCache)
+
+	input := &Input{
+		ProtoPackage:   "unittest",
+		InputDir:       "../../../testdata",
+		SubdirRewrites: nil,
+		PRFiles:        protoregistry.GlobalFiles,
+		Present:        true,
+	}
+	prop := &tableaupb.FieldProp{Refer: "DoesNotExistConf.ID"}
+
+	ok, err := InReferredSpace(context.Background(), prop, "1", input)
+	if err == nil {
+		t.Fatal("first InReferredSpace() error = nil, want load error")
+	}
+	if ok {
+		t.Errorf("first InReferredSpace() = true, want false")
+	}
+
+	ok, err = InReferredSpace(context.Background(), prop, "2", input)
+	if err != nil {
+		t.Fatalf("second InReferredSpace() error = %v, want nil (deduped)", err)
+	}
+	if !ok {
+		t.Errorf("second InReferredSpace() = false, want true (treat as present after first failure)")
+	}
+}
+
+func testHeader() *tableparser.Header {
+	return &tableparser.Header{
+		NameRow: 1,
+		TypeRow: 2,
+		NoteRow: 3,
+		DataRow: 4,
+	}
+}
+
+func TestValueSpace_AddFromTable(t *testing.T) {
+	header := testHeader()
+
+	t.Run("success", func(t *testing.T) {
+		table := book.NewTable([][]string{
+			{"ID", "Name"},
+			{"uint32", "string"},
+			{"id", "name"},
+			{"1", "apple"},
+			{"2", "orange"},
+		})
+		vs := NewValueSpace()
+		if err := vs.AddFromTable(header, table, "ID", "Item.xlsx", "Item"); err != nil {
+			t.Fatalf("AddFromTable() error = %v", err)
+		}
+		if !vs.Contains("1") || !vs.Contains("2") {
+			t.Errorf("value space = %v, want {1, 2}", vs.Values())
+		}
+	})
+
+	t.Run("missing column", func(t *testing.T) {
+		table := book.NewTable([][]string{
+			{"ID", "Name"},
+			{"uint32", "string"},
+			{"id", "name"},
+			{"1", "apple"},
+		})
+		err := NewValueSpace().AddFromTable(header, table, "Missing", "AssistSkill.xlsx", "AssistSkill")
+		if err == nil {
+			t.Fatal("AddFromTable() error = nil, want error")
+		}
+		d := xerrors.NewDesc(err)
+		if got := d.GetValue(xerrors.KeyReferBookName); got != "AssistSkill.xlsx" {
+			t.Errorf("ReferBookName = %v, want AssistSkill.xlsx", got)
+		}
+		if got := d.GetValue(xerrors.KeyReferSheetName); got != "AssistSkill" {
+			t.Errorf("ReferSheetName = %v, want AssistSkill", got)
+		}
+	})
+
+	t.Run("ignore parse error", func(t *testing.T) {
+		table := book.NewTable([][]string{
+			{"ID", "Name", "#IGNORE"},
+			{"uint32", "string", "bool"},
+			{"id", "name", "ignore"},
+			{"1", "apple", "not-a-bool"},
+		})
+		err := NewValueSpace().AddFromTable(header, table, "ID", "AssistSkill.xlsx", "AssistSkill")
+		if err == nil {
+			t.Fatal("AddFromTable() error = nil, want error")
+		}
+		d := xerrors.NewDesc(err)
+		if got := d.GetValue(xerrors.KeyReferBookName); got != "AssistSkill.xlsx" {
+			t.Errorf("ReferBookName = %v, want AssistSkill.xlsx", got)
+		}
+		if got := d.GetValue(xerrors.KeyReferSheetName); got != "AssistSkill" {
+			t.Errorf("ReferSheetName = %v, want AssistSkill", got)
+		}
+	})
+}
+
+func TestReferredCache_ExistsValue_loadFailureDedup(t *testing.T) {
+	cache := NewReferredCache()
+	var loads int32
+	loadFunc := func(refer string) (*ValueSpace, error) {
+		atomic.AddInt32(&loads, 1)
+		return nil, errors.New("load failed")
+	}
+
+	ok, err := cache.ExistsValue("Broken.ID", "1", loadFunc)
+	if err == nil {
+		t.Fatal("first ExistsValue() error = nil, want error")
+	}
+	if ok {
+		t.Errorf("first ExistsValue() = true, want false")
+	}
+
+	ok, err = cache.ExistsValue("Broken.ID", "2", loadFunc)
+	if err != nil {
+		t.Fatalf("second ExistsValue() error = %v, want nil", err)
+	}
+	if !ok {
+		t.Errorf("second ExistsValue() = false, want true")
+	}
+	if got := atomic.LoadInt32(&loads); got != 1 {
+		t.Errorf("loadFunc calls = %d, want 1", got)
+	}
+}
+
+func TestReferredCache_ExistsValue_loadFailureDedupConcurrent(t *testing.T) {
+	// All callers pass the RLock check before any one takes the write lock,
+	// so losers hit the double-checked `failed` branch under Lock.
+	cache := NewReferredCache()
+	var loads int32
+	start := make(chan struct{})
+	loadFunc := func(refer string) (*ValueSpace, error) {
+		atomic.AddInt32(&loads, 1)
+		return nil, errors.New("load failed")
+	}
+
+	const n = 32
+	type result struct {
+		ok  bool
+		err error
+	}
+	results := make([]result, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ok, err := cache.ExistsValue("BrokenConcurrent.ID", "v", loadFunc)
+			results[i] = result{ok, err}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&loads); got != 1 {
+		t.Errorf("loadFunc calls = %d, want 1", got)
+	}
+	var nErr, nOK int
+	for _, res := range results {
+		if res.err != nil {
+			nErr++
+			if res.ok {
+				t.Errorf("failed ExistsValue() = true, want false")
+			}
+			continue
+		}
+		nOK++
+		if !res.ok {
+			t.Errorf("deduped ExistsValue() = false, want true")
+		}
+	}
+	if nErr != 1 {
+		t.Errorf("error returns = %d, want 1", nErr)
+	}
+	if nOK != n-1 {
+		t.Errorf("deduped returns = %d, want %d", nOK, n-1)
+	}
+}
+
+func TestReferredCache_Reset(t *testing.T) {
+	cache := NewReferredCache()
+	vs := NewValueSpace()
+	vs.Add("1")
+	cache.Put("OK.ID", vs)
+
+	var loads int32
+	_, err := cache.ExistsValue("Broken.ID", "1", func(string) (*ValueSpace, error) {
+		atomic.AddInt32(&loads, 1)
+		return nil, errors.New("load failed")
+	})
+	if err == nil {
+		t.Fatal("ExistsValue() error = nil, want error")
+	}
+
+	cache.Reset()
+
+	if cache.Exists("OK.ID") {
+		t.Error("Exists(OK.ID) = true after Reset, want false")
+	}
+
+	_, err = cache.ExistsValue("Broken.ID", "1", func(string) (*ValueSpace, error) {
+		atomic.AddInt32(&loads, 1)
+		return nil, errors.New("load failed")
+	})
+	if err == nil {
+		t.Fatal("ExistsValue() after Reset error = nil, want load to be retried")
+	}
+	if got := atomic.LoadInt32(&loads); got != 2 {
+		t.Errorf("loadFunc calls = %d, want 2 (retried after Reset)", got)
+	}
+}
+
+func TestResetReferredCache(t *testing.T) {
+	ResetReferredCache()
+	t.Cleanup(ResetReferredCache)
+
+	prop := &tableaupb.FieldProp{Refer: "DoesNotExistConf.ID"}
+	input := &Input{
+		ProtoPackage: "unittest",
+		InputDir:     "../../../testdata",
+		PRFiles:      protoregistry.GlobalFiles,
+		Present:      true,
+	}
+	if _, err := InReferredSpace(context.Background(), prop, "1", input); err == nil {
+		t.Fatal("first InReferredSpace() error = nil, want load error")
+	}
+
+	ResetReferredCache()
+
+	if _, err := InReferredSpace(context.Background(), prop, "1", input); err == nil {
+		t.Fatal("InReferredSpace() after ResetReferredCache error = nil, want load to be retried")
 	}
 }

--- a/internal/confgen/parser.go
+++ b/internal/confgen/parser.go
@@ -317,6 +317,7 @@ type SheetParserExtInfo struct {
 	BookFormat     format.Format // workbook format
 	DryRun         options.DryRun
 	ErrorLimit     *options.ErrorLimitOption // error collection limits
+	ReferredCache  *fieldprop.ReferredCache
 }
 
 // NewSheetParser creates a new sheet parser.
@@ -992,7 +993,7 @@ func (p *sheetParser) parseFieldValue(fd protoreflect.FieldDescriptor, rawValue 
 				PRFiles:        p.extInfo.PRFiles,
 				Present:        present,
 			}
-			ok, err := fieldprop.InReferredSpace(p.ctx, fprop, rawValue, input)
+			ok, err := p.extInfo.ReferredCache.InReferredSpace(p.ctx, fprop, rawValue, input)
 			if err != nil {
 				return v, present, err
 			}

--- a/internal/localizer/i18n/config/message/en.yaml
+++ b/internal/localizer/i18n/config/message/en.yaml
@@ -20,6 +20,10 @@ confgen: |
   error[{{.ErrCode}}]: {{.ErrDesc}}
   Workbook: {{.BookName}}{{ if and (.PrimaryBookName) (not (eq .BookName .PrimaryBookName)) }} (Primary: {{.PrimaryBookName}}){{ end }}
   Worksheet: {{.SheetName}}{{ if and (.PrimarySheetName) (not (eq .SheetName .PrimarySheetName)) }} (Primary: {{.PrimarySheetName}}){{ end }}
+  {{- if .ReferBookName }}
+  ReferWorkbook: {{.ReferBookName}}
+  ReferWorksheet: {{.ReferSheetName}}
+  {{- end }}
   DataCellPos: {{.DataCellPos}}
   DataCell: {{.DataCell}}
   Reason: {{.Reason}}

--- a/internal/localizer/i18n/config/message/zh.yaml
+++ b/internal/localizer/i18n/config/message/zh.yaml
@@ -16,7 +16,9 @@ confgen: |
   error[{{.ErrCode}}]: {{.ErrDesc}}
   工作簿: {{.BookName}}{{ if and (.PrimaryBookName) (not (eq .BookName .PrimaryBookName)) }} (主工作簿: {{.PrimaryBookName}}){{ end }}
   工作表: {{.SheetName}}{{ if and (.PrimarySheetName) (not (eq .SheetName .PrimarySheetName)) }} (主工作表: {{.PrimarySheetName}}){{ end }}
-  单元格位置: {{.DataCellPos}}
+  {{ if .ReferBookName }}引用工作簿: {{.ReferBookName}}
+  引用工作表: {{.ReferSheetName}}
+  {{ end }}单元格位置: {{.DataCellPos}}
   单元格数据: {{.DataCell}}
   错误原因: {{.Reason}}
   {{ if .Help }}修复建议: {{.Help}}{{ end }}

--- a/internal/localizer/i18n/config/message/zh.yaml
+++ b/internal/localizer/i18n/config/message/zh.yaml
@@ -16,9 +16,11 @@ confgen: |
   error[{{.ErrCode}}]: {{.ErrDesc}}
   工作簿: {{.BookName}}{{ if and (.PrimaryBookName) (not (eq .BookName .PrimaryBookName)) }} (主工作簿: {{.PrimaryBookName}}){{ end }}
   工作表: {{.SheetName}}{{ if and (.PrimarySheetName) (not (eq .SheetName .PrimarySheetName)) }} (主工作表: {{.PrimarySheetName}}){{ end }}
-  {{ if .ReferBookName }}引用工作簿: {{.ReferBookName}}
+  {{- if .ReferBookName }}
+  引用工作簿: {{.ReferBookName}}
   引用工作表: {{.ReferSheetName}}
-  {{ end }}单元格位置: {{.DataCellPos}}
+  {{- end }}
+  单元格位置: {{.DataCellPos}}
   单元格数据: {{.DataCell}}
   错误原因: {{.Reason}}
   {{ if .Help }}修复建议: {{.Help}}{{ end }}

--- a/internal/x/xerrors/desc.go
+++ b/internal/x/xerrors/desc.go
@@ -25,6 +25,14 @@ const (
 	KeyPrimaryBookName  = "PrimaryBookName"  // primary workbook name
 	KeySheetName        = "SheetName"        // worksheet name
 	KeyPrimarySheetName = "PrimarySheetName" // primary worksheet name
+	// KeyReferBookName / KeyReferSheetName identify the referred target
+	// workbook / worksheet whose data actually triggered the error, when the
+	// current error is raised during refer value-space loading (see
+	// fieldprop.InReferredSpace). BookName / SheetName still identify the
+	// source sheet under generation, which is what users need to locate the
+	// refer expression in the schema.
+	KeyReferBookName  = "ReferBookName"
+	KeyReferSheetName = "ReferSheetName"
 	KeyNameCellPos      = "NameCellPos"      // name cell position
 	KeyNameCell         = "NameCell"         // name cell value
 	KeyTrimmedNameCell  = "TrimmedNameCell"  // trimmed name cell value
@@ -60,6 +68,8 @@ var keys = []string{
 	KeyPrimaryBookName,
 	KeySheetName,
 	KeyPrimarySheetName,
+	KeyReferBookName,
+	KeyReferSheetName,
 	KeyNameCellPos,
 	KeyNameCell,
 	KeyTrimmedNameCell,

--- a/internal/x/xerrors/desc.go
+++ b/internal/x/xerrors/desc.go
@@ -28,20 +28,20 @@ const (
 	// KeyReferBookName / KeyReferSheetName identify the referred target
 	// workbook / worksheet whose data actually triggered the error, when the
 	// current error is raised during refer value-space loading (see
-	// fieldprop.InReferredSpace). BookName / SheetName still identify the
+	// fieldprop.ReferredCache.InReferredSpace). BookName / SheetName still identify the
 	// source sheet under generation, which is what users need to locate the
 	// refer expression in the schema.
-	KeyReferBookName  = "ReferBookName"
-	KeyReferSheetName = "ReferSheetName"
-	KeyNameCellPos      = "NameCellPos"      // name cell position
-	KeyNameCell         = "NameCell"         // name cell value
-	KeyTrimmedNameCell  = "TrimmedNameCell"  // trimmed name cell value
-	KeyTypeCellPos      = "TypeCellPos"      // type cell position
-	KeyTypeCell         = "TypeCell"         // type cell value
-	KeyNoteCellPos      = "NoteCellPos"      // note cell position
-	KeyNoteCell         = "NoteCell"         // note cell value
-	KeyDataCellPos      = "DataCellPos"      // data cell position
-	KeyDataCell         = "DataCell"         // data data value
+	KeyReferBookName   = "ReferBookName"
+	KeyReferSheetName  = "ReferSheetName"
+	KeyNameCellPos     = "NameCellPos"     // name cell position
+	KeyNameCell        = "NameCell"        // name cell value
+	KeyTrimmedNameCell = "TrimmedNameCell" // trimmed name cell value
+	KeyTypeCellPos     = "TypeCellPos"     // type cell position
+	KeyTypeCell        = "TypeCell"        // type cell value
+	KeyNoteCellPos     = "NoteCellPos"     // note cell position
+	KeyNoteCell        = "NoteCell"        // note cell value
+	KeyDataCellPos     = "DataCellPos"     // data cell position
+	KeyDataCell        = "DataCell"        // data data value
 
 	KeyPBMessage   = "PBMessage"   // protobuf message name
 	KeyPBFieldName = "PBFieldName" // protobuf message field name

--- a/internal/x/xerrors/desc_test.go
+++ b/internal/x/xerrors/desc_test.go
@@ -1097,3 +1097,23 @@ func TestNewDesc_GroupEndToEnd(t *testing.T) {
 		assertGroupOutput(t, NewDesc(root.Join()))
 	})
 }
+
+func TestNewDescReferBookAndSheet(t *testing.T) {
+	err := WrapKV(E2013("not-a-bool", errors.New("parse")),
+		KeyModule, ModuleConf,
+		KeyBookName, "Affix.xlsx",
+		KeySheetName, "AffixConf",
+		KeyReferBookName, "AssistSkill.xlsx",
+		KeyReferSheetName, "AssistSkill",
+		KeyDataCellPos, "C4",
+		KeyDataCell, "not-a-bool",
+	)
+	d := NewDesc(err)
+	require.NotNil(t, d)
+	got := d.Stringify(false)
+	assert.Contains(t, got, "Workbook: Affix.xlsx")
+	assert.Contains(t, got, "Worksheet: AffixConf")
+	assert.Contains(t, got, "ReferWorkbook: AssistSkill.xlsx")
+	assert.Contains(t, got, "ReferWorksheet: AssistSkill")
+	assert.Contains(t, got, "DataCellPos: C4")
+}

--- a/load/load.go
+++ b/load/load.go
@@ -11,6 +11,7 @@ import (
 	"buf.build/go/protovalidate"
 	"github.com/tableauio/tableau/format"
 	"github.com/tableauio/tableau/internal/confgen"
+	"github.com/tableauio/tableau/internal/confgen/fieldprop"
 	"github.com/tableauio/tableau/internal/importer"
 	"github.com/tableauio/tableau/internal/x/xerrors"
 	"github.com/tableauio/tableau/internal/x/xfs"
@@ -203,6 +204,7 @@ func loadOrigin(msg proto.Message, dir string, opts *MessagerOptions) error {
 			SubdirRewrites: subdirRewrites,
 			PRFiles:        protoregistry.GlobalFiles,
 			BookFormat:     self.Format(),
+			ReferredCache:  fieldprop.NewReferredCache(),
 		},
 	}
 	collector := xerrors.NewCollector(opts.GetMaxErrorsPerSheet())


### PR DESCRIPTION
## Problem

When a refer target (e.g. `AssistSkillConf.ID`) fails to load its value space -- for instance because the referred sheet has a broken row that makes `RangeDataRows` return an error via `Ignored()` / `parseColumns` / etc. -- every row on the referring side would re-invoke `loadFunc` and re-emit the same error, producing N duplicate errors for one root cause.

Additionally, those N errors were wrapped with the **source** sheet's `BookName` / `SheetName` (the sheet under generation), which pointed users away from the sheet actually containing the offending row.

## Changes

### `ReferredCache`: negative caching
- New `failed map[string]struct{}` tracks refer expressions whose load has already failed.
- On `loadFunc(refer)` error, the failure is still surfaced to the caller (the collector receives the real error once), and the refer is marked as failed.
- Subsequent `ExistsValue` calls for the same refer short-circuit to `(true, nil)` instead of re-triggering the load. This preserves error visibility while eliminating the N-way duplication.
- Double-checked locking treats `failed` the same way as `references`, so concurrent callers don't race into duplicate loads.

### `AddFromTable`: locate errors on the referred target
- Wraps `RangeDataRows` errors with `KeyReferBookName` / `KeyReferSheetName`.
- Outer confgen wrappers still set `BookName` / `SheetName` to the source sheet under generation (which is what users need to find the refer expression in the schema), while the new keys pinpoint the referred workbook / worksheet that actually contains the offending row.

### Supporting bits
- `xerrors/desc.go`: add `KeyReferBookName` / `KeyReferSheetName` constants and register them in `keys`.
- `i18n` templates (`zh.yaml` / `en.yaml`): render `ReferWorkbook` / `ReferWorksheet` (引用工作簿 / 引用工作表) when present.

## Behavior after this PR

Given `AffixConf` referring `AssistSkillConf.ID` and `AssistSkill.xlsx` having a broken row (e.g. an `#IGNORE` cell that fails to parse as bool):

| Error source | Before | After |
|---|---|---|
| `AssistSkill.xlsx` self-generation error | 1 | 1 |
| `AffixConf` first refer check that triggers the load | 1 | 1 |
| Every subsequent row referring the same target | N | 0 |
| Wrapped `BookName` / `SheetName` in the refer-side error | source sheet only | source sheet + `ReferBookName` / `ReferSheetName` pointing at `AssistSkill.xlsx` |

## Verification
- `go build ./...`
- `go test ./internal/confgen/... ./internal/confgen/fieldprop/...`
