### PR TITLE
fix(protogen): stop preserveFieldNumbers from polluting type infos

### DIFF
--- a/internal/protogen/preprocess_test.go
+++ b/internal/protogen/preprocess_test.go
@@ -1,0 +1,93 @@
+package protogen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tableauio/tableau/internal/x/xfs"
+	"github.com/tableauio/tableau/options"
+)
+
+// prepareGeneratedProto writes a proto file into the output dir, mimicking a
+// previously generated one, whose message type is absent from both the input
+// workbooks and the predefined proto files.
+func prepareGeneratedProto(t *testing.T, outdir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(outdir, xfs.DefaultDirPerm))
+	content := `syntax = "proto3";
+package protoconf;
+option go_package = "github.com/tableauio/tableau/test/dev/protoconf";
+
+import "tableau/protobuf/tableau.proto";
+
+option (tableau.workbook) = {name:"Stale#*.csv" namerow:1 typerow:2 datarow:3};
+
+message StaleConf {
+  option (tableau.worksheet) = {name:"StaleConf"};
+
+  map<uint32, uint32> stale_map = 1 [(tableau.field) = {key:"ID" layout:LAYOUT_VERTICAL}];
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(outdir, "stale_conf.proto"), []byte(content), xfs.DefaultFilePerm))
+}
+
+func newPreserveFieldNumbersGenerator(t *testing.T, subdir string) *Generator {
+	t.Helper()
+	outputDir := t.TempDir()
+	// NOTE: the outdir must be one of the proto paths, so that the previously
+	// generated protos are resolvable, as real configs do.
+	outdir := filepath.Join(outputDir, subdir)
+	prepareGeneratedProto(t, outdir)
+	return NewGeneratorWithOptions("protoconf", "testdata", outputDir, &options.Options{
+		LocationName: "Asia/Shanghai",
+		Proto: &options.ProtoOption{
+			Input: &options.ProtoInputOption{
+				ProtoPaths: []string{"../../proto", outdir},
+			},
+			Output: &options.ProtoOutputOption{
+				Subdir:               subdir,
+				PreserveFieldNumbers: true,
+			},
+		},
+	})
+}
+
+// Test_preprocess_preserveFieldNumbersNotPollutingTypeInfos asserts that
+// preserveFieldNumbers only warms up the registry cache, without leaking the
+// previously generated protos into type infos, otherwise the types only
+// existing in them would be mistaken for predefined ones, which makes the
+// exporter import a proto file that no longer exists.
+func Test_preprocess_preserveFieldNumbersNotPollutingTypeInfos(t *testing.T) {
+	gen := newPreserveFieldNumbersGenerator(t, "default")
+	outdir := filepath.Join(gen.OutputDir, gen.OutputOpt.Subdir)
+
+	require.NoError(t, gen.preprocess(false, true))
+
+	// The message only exists in the previously generated proto, so it must not
+	// be treated as a predefined type.
+	assert.Nil(t, gen.typeInfos.Get("protoconf.StaleConf"),
+		"type in previously generated proto should not be in type infos")
+
+	// Meanwhile the registry including generated protos should be cached before
+	// the generated protos were deleted by prepareOutdir, so that
+	// preserveFieldNumbers still works afterwards.
+	require.NoFileExists(t, filepath.Join(outdir, "stale_conf.proto"), "generated proto should have been deleted")
+	files := gen.getProtoRegistryFilesWithGenerated()
+	_, err := files.FindDescriptorByName("protoconf.StaleConf")
+	assert.NoError(t, err, "registry with generated protos should be cached before deletion")
+}
+
+// Test_preprocess_useGeneratedProtosPopulatesTypeInfos asserts that the
+// advanced first-pass mode still sees the previously generated protos as
+// predefined types.
+func Test_preprocess_useGeneratedProtosPopulatesTypeInfos(t *testing.T) {
+	gen := newPreserveFieldNumbersGenerator(t, "default")
+
+	require.NoError(t, gen.preprocess(true, false))
+
+	assert.NotNil(t, gen.typeInfos.Get("protoconf.StaleConf"),
+		"type in previously generated proto should be in type infos")
+}

--- a/internal/protogen/protogen.go
+++ b/internal/protogen/protogen.go
@@ -134,10 +134,19 @@ func (gen *Generator) preprocess(useGeneratedProtos, delExisted bool) error {
 	outdir := filepath.Join(gen.OutputDir, gen.OutputOpt.Subdir)
 	// parse custom imported proto files
 	protoRegistryFiles := gen.ProtoRegistryFiles
-	// preserveFieldNumbers also needs generated protos parsed before they
-	// are deleted below.
-	if useGeneratedProtos || gen.OutputOpt.PreserveFieldNumbers {
+	if useGeneratedProtos {
+		// NOTE: the advanced first-pass mode parses only the specified
+		// workbooks, so the previously generated protos are intended to serve
+		// as the predefined types of the others. They are not deleted in this
+		// mode, hence still importable.
 		protoRegistryFiles = gen.getProtoRegistryFilesWithGenerated()
+	} else if gen.OutputOpt.PreserveFieldNumbers {
+		// Cache the previously generated protos before they are deleted below,
+		// as they are not parsable any more once deleted. The result is
+		// deliberately discarded rather than used as the type infos, otherwise
+		// the types only existing in them would be mistaken for predefined
+		// ones, whose proto file is never regenerated in this run.
+		_ = gen.getProtoRegistryFilesWithGenerated()
 	}
 	gen.typeInfos = xproto.GetAllTypeInfo(protoRegistryFiles, gen.ProtoPackage)
 	return prepareOutdir(outdir, gen.InputOpt.ProtoFiles, delExisted)


### PR DESCRIPTION
## Problem

`preserveFieldNumbers` needs the previously generated protos parsed before `prepareOutdir` deletes them, but it reused the resulting registry as the type infos as well:

```go
protoRegistryFiles := gen.ProtoRegistryFiles
// preserveFieldNumbers also needs generated protos parsed before they
// are deleted below.
if useGeneratedProtos || gen.OutputOpt.PreserveFieldNumbers {
    protoRegistryFiles = gen.getProtoRegistryFilesWithGenerated()
}
gen.typeInfos = xproto.GetAllTypeInfo(protoRegistryFiles, gen.ProtoPackage)
```

As a result, the types only existing in the previously generated protos were mistaken for predefined ones.

### Failure path

With `GenAll` + `preserveFieldNumbers: true`, given a sheet referring to a type that was removed from the workbooks and now only exists in a previously generated proto:

1. the type is found in the polluted type infos, hence judged as `Predefined: true`;
2. the exporter emits `import "<that file>.proto"`;
3. but `GenAll` has already deleted that file and will never regenerate it.

So protogen succeeded and produced **uncompilable protos**. The expected behavior is a clear `predefined type not found` error.

That the type infos are meant to hold predefined types only is confirmed by them being populated dynamically during the first pass (`sheet_mode.go`, `protogen.go`), i.e. the baseline should contain nothing but predefined types.

## Fix

Decouple the cache warm-up from the type infos. `getProtoRegistryFilesWithGenerated` is guarded by `sync.Once`, so calling it merely to populate the cache is enough — the very same registry is still shared with `findMDFromGeneratedProtos` afterwards, keeping `preserveFieldNumbers` working, while the type infos are built from the predefined protos only, unless the advanced first-pass mode is enabled.

## Tests

Two regression tests, verified to be meaningful by temporarily reverting the fix:

| | before fix | after fix |
|---|---|---|
| `Test_preprocess_preserveFieldNumbersNotPollutingTypeInfos` | **FAIL** | PASS |
| `Test_preprocess_useGeneratedProtosPopulatesTypeInfos` | PASS | PASS |

The first one also asserts the warm-up still works, i.e. the previously generated proto is deleted by `prepareOutdir` yet still resolvable from the cached registry. The second one guards against overcorrecting: the advanced first-pass mode must keep seeing those types.

Full `go test ./...` passes.